### PR TITLE
fix(security): harden shell scripts against code injection and path traversal

### DIFF
--- a/skills/listenhub/SKILL.md
+++ b/skills/listenhub/SKILL.md
@@ -80,6 +80,13 @@ The following are **internal implementation details** that AI cannot reliably kn
 Users don't need to know: Episode IDs, API structure, polling mechanisms, credits, endpoint differences.
 Users only need: Say idea → wait a moment → get the link.
 
+## Security
+
+- User-provided content (text, URLs) is transmitted to the ListenHub API (`api.marswave.ai`) for processing. Do not pass sensitive or confidential information as input.
+- The `--source-url` parameter accepts external URLs whose content is fetched and processed by the backend. Only use trusted URLs.
+- API keys are stored locally in environment variables and transmitted via HTTPS. Never log or display full API keys.
+- Version checks connect to `raw.githubusercontent.com` (read-only, no code execution). Set `LISTENHUB_SKIP_VERSION_CHECK=1` to disable.
+
 ## Environment
 
 ### ListenHub API Key

--- a/skills/listenhub/scripts/check-status.sh
+++ b/skills/listenhub/scripts/check-status.sh
@@ -81,6 +81,8 @@ if [ -z "$EPISODE_ID" ]; then
   exit 1
 fi
 
+validate_id "$EPISODE_ID" "episode-id"
+
 case "$TYPE" in
   podcast)
     ENDPOINT="podcast/episodes/${EPISODE_ID}"

--- a/skills/listenhub/scripts/create-podcast-audio.sh
+++ b/skills/listenhub/scripts/create-podcast-audio.sh
@@ -75,6 +75,8 @@ if [ -z "$EPISODE_ID" ]; then
   exit 1
 fi
 
+validate_id "$EPISODE_ID" "episode-id"
+
 # Build request body
 if [ -n "$SCRIPTS_FILE" ]; then
   if [ "$SCRIPTS_FILE" = "-" ]; then

--- a/skills/listenhub/scripts/generate-video.sh
+++ b/skills/listenhub/scripts/generate-video.sh
@@ -35,4 +35,6 @@ if [ -z "$EPISODE_ID" ]; then
   exit 1
 fi
 
+validate_id "$EPISODE_ID" "episode-id"
+
 api_post "storybook/episodes/${EPISODE_ID}/video" "{}"

--- a/skills/listenhub/scripts/lib.sh
+++ b/skills/listenhub/scripts/lib.sh
@@ -51,7 +51,10 @@ check_version() {
 }
 
 # Run version check (notify-only, no auto-update)
-check_version
+# Set LISTENHUB_SKIP_VERSION_CHECK=1 to disable
+if [ "${LISTENHUB_SKIP_VERSION_CHECK:-}" != "1" ]; then
+  check_version
+fi
 
 # Load API key from shell config (try multiple sources)
 # Extract value safely without eval to prevent code injection

--- a/skills/listenhub/scripts/lib.sh
+++ b/skills/listenhub/scripts/lib.sh
@@ -69,12 +69,24 @@ else
     line=$(grep -m1 '^[[:space:]]*export[[:space:]]\{1,\}LISTENHUB_API_KEY=' "$file" 2>/dev/null) || return 1
     # Strip everything up to and including the first =
     local value="${line#*=}"
-    # Remove surrounding quotes (single or double)
-    value="${value#\"}" ; value="${value%\"}"
-    value="${value#\'}" ; value="${value%\'}"
-    # Remove trailing comments and whitespace
-    value="${value%%#*}"
-    value=$(printf '%s' "$value" | sed 's/[[:space:]]*$//')
+    # Extract based on quoting style
+    case "$value" in
+      \"*)
+        # Double-quoted: extract between first and last double quote
+        value="${value#\"}"
+        value="${value%\"*}"
+        ;;
+      \'*)
+        # Single-quoted: extract between first and last single quote
+        value="${value#\'}"
+        value="${value%\'*}"
+        ;;
+      *)
+        # Unquoted: strip trailing comments and whitespace
+        value="${value%%#*}"
+        value="${value%"${value##*[![:space:]]}"}"
+        ;;
+    esac
     [ -n "$value" ] && printf '%s' "$value"
   }
   _key=$(_extract_api_key ~/.zshrc) || _key=$(_extract_api_key ~/.bashrc) || _key=""

--- a/skills/listenhub/scripts/lib.sh
+++ b/skills/listenhub/scripts/lib.sh
@@ -39,80 +39,47 @@ check_version() {
   IFS='.' read -r local_major local_minor local_patch <<< "$local_ver"
   IFS='.' read -r remote_major remote_minor remote_patch <<< "$remote_ver"
 
-  # Only update if remote version is newer (not just different)
-  # This prevents downgrading when local version is ahead of remote
+  # Notify if remote version is newer (major/minor bump or patch bump)
   if [ "$remote_major" -gt "$local_major" ] || \
-     { [ "$remote_major" -eq "$local_major" ] && [ "$remote_minor" -gt "$local_minor" ]; }; then
+     { [ "$remote_major" -eq "$local_major" ] && [ "$remote_minor" -gt "$local_minor" ]; } || \
+     { [ "$remote_major" -eq "$local_major" ] && [ "$remote_minor" -eq "$local_minor" ] && [ "$remote_patch" -gt "$local_patch" ]; }; then
     echo "┌─────────────────────────────────────────────────────┐" >&2
-    echo "│  Auto-updating: $local_ver → $remote_ver" >&2
-    echo "└─────────────────────────────────────────────────────┘" >&2
-
-    # Download and replace scripts using curl (non-interactive, no git required)
-    local base_url="https://raw.githubusercontent.com/marswaveai/skills/main/skills/listenhub"
-    local api_url="https://api.github.com/repos/marswaveai/skills/contents/skills/listenhub/scripts"
-    local update_success=true
-
-    # Update VERSION file
-    if ! curl -fsSL --max-time 10 "$base_url/VERSION" -o "$VERSION_FILE.tmp" 2>/dev/null; then
-      update_success=false
-    fi
-
-    # Fetch remote script list from GitHub API and download all scripts
-    if [ "$update_success" = true ]; then
-      local script_list
-      script_list=$(curl -fsSL --max-time 10 "$api_url" 2>/dev/null | grep -o '"name":"[^"]*\.sh"' | cut -d'"' -f4)
-
-      if [ -z "$script_list" ]; then
-        update_success=false
-      else
-        for script_name in $script_list; do
-          if ! curl -fsSL --max-time 10 "$base_url/scripts/$script_name" -o "$SCRIPT_DIR/$script_name.tmp" 2>/dev/null; then
-            update_success=false
-            break
-          fi
-        done
-      fi
-    fi
-
-    # If all downloads succeeded, replace files atomically
-    if [ "$update_success" = true ]; then
-      # Move all script files first
-      for script_tmp in "$SCRIPT_DIR"/*.sh.tmp; do
-        [ -f "$script_tmp" ] || continue
-        local script="${script_tmp%.tmp}"
-        mv -f "$script_tmp" "$script" && chmod +x "$script"
-      done
-      # Only update VERSION after all scripts are successfully moved
-      mv -f "$VERSION_FILE.tmp" "$VERSION_FILE" 2>/dev/null || true
-      echo "│  ✓ Updated successfully to $remote_ver                  │" >&2
-    else
-      # Cleanup temp files on failure
-      rm -f "$VERSION_FILE.tmp" "$SCRIPT_DIR"/*.sh.tmp 2>/dev/null || true
-      echo "│  Auto-update failed. Run manually:                  │" >&2
-      echo "│  npx skills add marswaveai/skills                   │" >&2
-    fi
-  # Patch update available (remote patch > local patch) → notify only
-  elif [ "$remote_major" -eq "$local_major" ] && [ "$remote_minor" -eq "$local_minor" ] && \
-       [ "$remote_patch" -gt "$local_patch" ]; then
-    echo "┌─────────────────────────────────────────────────────┐" >&2
-    echo "│  Patch update available: $local_ver → $remote_ver" >&2
+    echo "│  Update available: $local_ver → $remote_ver" >&2
     echo "│  Run: npx skills add marswaveai/skills             │" >&2
     echo "└─────────────────────────────────────────────────────┘" >&2
   fi
 }
 
-# Run version check (auto-update via curl if available)
+# Run version check (notify-only, no auto-update)
 check_version
 
 # Load API key from shell config (try multiple sources)
-# Note: source may fail on zsh-specific syntax, so we use || true
+# Extract value safely without eval to prevent code injection
 if [ -n "${LISTENHUB_API_KEY:-}" ]; then
   : # Already set, skip loading
-elif [ -f ~/.zshrc ]; then
-  # Extract just the export line to avoid zsh syntax issues
-  eval "$(grep 'export LISTENHUB_API_KEY' ~/.zshrc 2>/dev/null || true)"
-elif [ -f ~/.bashrc ]; then
-  eval "$(grep 'export LISTENHUB_API_KEY' ~/.bashrc 2>/dev/null || true)"
+else
+  _extract_api_key() {
+    local file="$1"
+    [ -f "$file" ] || return 1
+    # Match: export LISTENHUB_API_KEY="value" or export LISTENHUB_API_KEY='value' or unquoted
+    local line
+    line=$(grep -m1 '^[[:space:]]*export[[:space:]]\{1,\}LISTENHUB_API_KEY=' "$file" 2>/dev/null) || return 1
+    # Strip everything up to and including the first =
+    local value="${line#*=}"
+    # Remove surrounding quotes (single or double)
+    value="${value#\"}" ; value="${value%\"}"
+    value="${value#\'}" ; value="${value%\'}"
+    # Remove trailing comments and whitespace
+    value="${value%%#*}"
+    value=$(printf '%s' "$value" | sed 's/[[:space:]]*$//')
+    [ -n "$value" ] && printf '%s' "$value"
+  }
+  _key=$(_extract_api_key ~/.zshrc) || _key=$(_extract_api_key ~/.bashrc) || _key=""
+  if [ -n "$_key" ]; then
+    export LISTENHUB_API_KEY="$_key"
+  fi
+  unset -f _extract_api_key
+  unset _key
 fi
 
 # === Environment Checks ===
@@ -158,6 +125,19 @@ EOF
 # Run checks
 check_curl
 check_api_key
+
+# === Input Validation ===
+
+# Validate that an ID contains only safe characters (alphanumeric, hyphen, underscore)
+# Usage: validate_id "value" "field_name"
+validate_id() {
+  local value="$1"
+  local name="${2:-id}"
+  if [[ ! "$value" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+    echo "Error: Invalid $name (only alphanumeric, hyphen, underscore allowed): $value" >&2
+    exit 1
+  fi
+}
 
 # === API Helpers ===
 


### PR DESCRIPTION
## Security Hardening

### 1. Remove auto-update mechanism (CRITICAL)
`check_version()` previously downloaded scripts from GitHub and replaced local files without any checksum or signature verification. If the upstream repo were compromised, malicious code would be automatically deployed to all users.

**Fix**: Replace with notify-only version check. Users run `npx skills add marswaveai/skills` to update manually.

### 2. Remove path traversal risk in auto-update (CRITICAL)
The auto-update fetched filenames from the GitHub API and used them directly to write files to disk. A malicious filename like `../../.zshrc.sh` could write files to arbitrary locations.

**Fix**: Removed along with the auto-update mechanism.

### 3. Fix eval injection (HIGH)
`eval "$(grep 'export LISTENHUB_API_KEY' ~/.zshrc)"` executed the entire matched line. If the line contained command substitution or other shell syntax, it would be executed.

**Fix**: Replace eval with safe string extraction that parses the value based on quoting style (double-quoted, single-quoted, or unquoted).

### 4. Add API path input validation (MEDIUM)
EPISODE_ID and other user inputs were concatenated directly into URL paths. Inputs containing `../` could manipulate API endpoints.

**Fix**: Add `validate_id()` helper that restricts IDs to alphanumeric characters, hyphens, and underscores.

### 5. Version check opt-out (LOW)
Add `LISTENHUB_SKIP_VERSION_CHECK=1` environment variable to allow users to disable remote version checks to `raw.githubusercontent.com`.

### 6. Security disclosure in SKILL.md (LOW)
Document data transmission, URL handling, and API key storage behavior in a dedicated Security section.