### PR TITLE
feat(image-gen): add base64 reference image support

### DIFF
--- a/asr/SKILL.md
+++ b/asr/SKILL.md
@@ -67,29 +67,32 @@ If `coli` is missing, stop here and do not proceed.
 
 ### Step 0: Config Setup
 
-Follow `shared/config-pattern.md` Step 0.
+Follow `shared/config-pattern.md` Step 0 (Zero-Question Boot).
 
-Initial defaults:
+**If file doesn't exist** — silently create with defaults and proceed:
 ```bash
-# 当前目录:
 mkdir -p ".listenhub/asr"
 echo '{"model":"sensevoice","polish":true}' > ".listenhub/asr/config.json"
 CONFIG_PATH=".listenhub/asr/config.json"
+CONFIG=$(cat "$CONFIG_PATH")
+```
+**Do NOT ask any setup questions.** Proceed directly to the Interaction Flow with sensible defaults (sensevoice model, polish enabled).
 
-# 全局:
-mkdir -p "$HOME/.listenhub/asr"
-echo '{"model":"sensevoice","polish":true}' > "$HOME/.listenhub/asr/config.json"
-CONFIG_PATH="$HOME/.listenhub/asr/config.json"
+**If file exists** — read config silently and proceed:
+```bash
+CONFIG_PATH=".listenhub/asr/config.json"
+[ ! -f "$CONFIG_PATH" ] && CONFIG_PATH="$HOME/.listenhub/asr/config.json"
+CONFIG=$(cat "$CONFIG_PATH")
 ```
 
-Config summary display:
+### Setup Flow (user-initiated reconfigure only)
+
+Only run when the user explicitly asks to reconfigure. Display current settings:
 ```
 当前配置 (asr)：
   模型：sensevoice / whisper-tiny.en
   润色：开启 / 关闭
 ```
-
-### Setup Flow (first run or reconfigure)
 
 Ask in order:
 

--- a/content-parser/SKILL.md
+++ b/content-parser/SKILL.md
@@ -146,7 +146,8 @@ Wait for explicit confirmation before calling the API.
    TASK_ID="<id-from-step-3>"
    for i in $(seq 1 60); do
      RESULT=$(curl -sS "https://api.marswave.ai/openapi/v1/content/extract/$TASK_ID" \
-       -H "Authorization: Bearer $LISTENHUB_API_KEY" 2>/dev/null)
+       -H "Authorization: Bearer $LISTENHUB_API_KEY" \
+       -H "X-Source: skills" 2>/dev/null)
      STATUS=$(echo "$RESULT" | tr -d '\000-\037\177' | jq -r '.data.status // "processing"')
      case "$STATUS" in
        completed) echo "$RESULT"; exit 0 ;;
@@ -207,6 +208,7 @@ Wait for explicit confirmation before calling the API.
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/content/extract" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   -d '{
     "source": {
       "type": "url",
@@ -219,7 +221,8 @@ curl -sS -X POST "https://api.marswave.ai/openapi/v1/content/extract" \
 
 ```bash
 curl -sS "https://api.marswave.ai/openapi/v1/content/extract/69a7dac700cf95938f86d9bb" \
-  -H "Authorization: Bearer $LISTENHUB_API_KEY"
+  -H "Authorization: Bearer $LISTENHUB_API_KEY" \
+  -H "X-Source: skills"
 ```
 
 5. Present extracted content preview and offer next actions.
@@ -237,6 +240,7 @@ curl -sS "https://api.marswave.ai/openapi/v1/content/extract/69a7dac700cf95938f8
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/content/extract" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   -d '{
     "source": {
       "type": "url",

--- a/content-parser/SKILL.md
+++ b/content-parser/SKILL.md
@@ -48,25 +48,33 @@ Follow `shared/config-pattern.md` § API Key Check. If the key is missing, stop 
 
 ## Step 0: Config Setup
 
-Follow `shared/config-pattern.md` Step 0.
+Follow `shared/config-pattern.md` Step 0 (Zero-Question Boot).
 
-**If file doesn't exist** — ask location, then create immediately:
+**If file doesn't exist** — silently create with defaults and proceed:
 ```bash
 mkdir -p ".listenhub/content-parser"
 echo '{"autoDownload":true}' > ".listenhub/content-parser/config.json"
 CONFIG_PATH=".listenhub/content-parser/config.json"
-# (or $HOME/.listenhub/content-parser/config.json for global)
+CONFIG=$(cat "$CONFIG_PATH")
 ```
-Then run **Setup Flow** below.
+**Do NOT ask any setup questions.** Proceed directly to the Interaction Flow.
 
-**If file exists** — read config, display summary, and confirm:
+**If file exists** — read config silently and proceed:
+```bash
+CONFIG_PATH=".listenhub/content-parser/config.json"
+[ ! -f "$CONFIG_PATH" ] && CONFIG_PATH="$HOME/.listenhub/content-parser/config.json"
+CONFIG=$(cat "$CONFIG_PATH")
+```
+
+### Setup Flow (user-initiated reconfigure only)
+
+Only run when the user explicitly asks to reconfigure. Display current settings:
 ```
 当前配置 (content-parser)：
   自动下载：{是 / 否}
 ```
-Ask: "使用已保存的配置？" → **确认，直接继续** / **重新配置**
 
-### Setup Flow (first run or reconfigure)
+Then ask:
 
 1. **autoDownload**: "自动保存提取的内容到当前目录？"
    - "是（推荐）" → `autoDownload: true`

--- a/content-parser/SKILL.md
+++ b/content-parser/SKILL.md
@@ -167,13 +167,18 @@ Wait for explicit confirmation before calling the API.
    ```
 6. When notified, **download and present result**:
 
-   If `autoDownload` is `true`:
-   - Write `{taskId}-extracted.md` to the **current directory** — full extracted content in markdown
-   - Write `{taskId}-extracted.json` to the **current directory** — full raw API response data
+   If `autoDownload` is `true`, generate a slug from the extracted title (falling back to domain name if no title). Follow `shared/config-pattern.md` § Artifact Naming for slug generation and dedup.
+
+   - Write `{slug}.md` to the **current directory** — full extracted content in markdown
+   - Write `{slug}.json` to the **current directory** — full raw API response data
 
    ```bash
-   echo "$CONTENT_MD" > "${TASK_ID}-extracted.md"
-   echo "$RESULT" > "${TASK_ID}-extracted.json"
+   SLUG="{title-slug}"  # e.g. "topology-wikipedia"
+   # Dedup: check if files exist
+   BASE="$SLUG"; i=2
+   while [ -e "${SLUG}.md" ] || [ -e "${SLUG}.json" ]; do SLUG="${BASE}-${i}"; i=$((i+1)); done
+   echo "$CONTENT_MD" > "${SLUG}.md"
+   echo "$RESULT" > "${SLUG}.json"
    ```
 
    Present:
@@ -186,8 +191,8 @@ Wait for explicit confirmation before calling the API.
    消耗积分：{credits}
 
    已保存到当前目录：
-     {taskId}-extracted.md
-     {taskId}-extracted.json
+     {slug}.md
+     {slug}.json
    ```
 
 7. Show a preview of the extracted content (first ~500 chars)

--- a/explainer/SKILL.md
+++ b/explainer/SKILL.md
@@ -179,7 +179,8 @@ Wait for explicit confirmation before calling any API.
    EPISODE_ID="<id-from-step-1>"
    for i in $(seq 1 30); do
      RESULT=$(curl -sS "https://api.marswave.ai/openapi/v1/storybook/episodes/$EPISODE_ID" \
-       -H "Authorization: Bearer $LISTENHUB_API_KEY" 2>/dev/null)
+       -H "Authorization: Bearer $LISTENHUB_API_KEY" \
+       -H "X-Source: skills" 2>/dev/null)
      STATUS=$(echo "$RESULT" | tr -d '\000-\037\177' | jq -r '.data.processStatus // "pending"')
      case "$STATUS" in
        success|completed) echo "$RESULT"; exit 0 ;;
@@ -216,7 +217,8 @@ Wait for explicit confirmation before calling any API.
    EPISODE_ID="<id-from-step-1>"
    for i in $(seq 1 30); do
      RESULT=$(curl -sS "https://api.marswave.ai/openapi/v1/storybook/episodes/$EPISODE_ID" \
-       -H "Authorization: Bearer $LISTENHUB_API_KEY" 2>/dev/null)
+       -H "Authorization: Bearer $LISTENHUB_API_KEY" \
+       -H "X-Source: skills" 2>/dev/null)
      STATUS=$(echo "$RESULT" | tr -d '\000-\037\177' | jq -r '.data.videoStatus // "pending"')
      case "$STATUS" in
        success|completed) echo "$RESULT"; exit 0 ;;
@@ -298,6 +300,7 @@ echo "$NEW_CONFIG" > "$CONFIG_PATH"
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/storybook/episodes" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   -d '{
     "sources": [{"type": "text", "content": "Introduce Claude Code: what it is, key features, and how to get started"}],
     "speakers": [{"speakerId": "cozy-man-english"}],

--- a/explainer/SKILL.md
+++ b/explainer/SKILL.md
@@ -37,7 +37,7 @@ Generate explainer videos that combine a single narrator's voiceover with AI-gen
 - Follow `shared/common-patterns.md` for polling, errors, and interaction patterns
 - Always read config following `shared/config-pattern.md` before any interaction
 - Never hardcode speaker IDs — always fetch from the speakers API
-- Never save files to `~/Downloads/` — use `.listenhub/explainer/` from config
+- Never save files to `~/Downloads/` or `.listenhub/` — save artifacts to the current working directory with friendly topic-based names (see `shared/config-pattern.md` § Artifact Naming)
 - Explainer uses exactly 1 speaker
 - Mode must be `info` (for Info style) or `story` (for Story style) — never `slides` (use `/slides` skill instead)
 
@@ -57,7 +57,7 @@ Follow `shared/config-pattern.md` Step 0 (Zero-Question Boot).
 **If file doesn't exist** — silently create with defaults and proceed:
 ```bash
 mkdir -p ".listenhub/explainer"
-echo '{"outputDir":".listenhub","outputMode":"inline","language":null,"defaultStyle":null,"defaultSpeakers":{}}' > ".listenhub/explainer/config.json"
+echo '{"outputMode":"inline","language":null,"defaultStyle":null,"defaultSpeakers":{}}' > ".listenhub/explainer/config.json"
 CONFIG_PATH=".listenhub/explainer/config.json"
 CONFIG=$(cat "$CONFIG_PATH")
 ```
@@ -210,10 +210,10 @@ Wait for explicit confirmation before calling any API.
    在线查看：https://listenhub.ai/app/explainer/{episodeId}
    ```
 
-   **`download` or `both`**: Also save the script file.
-   - Create `.listenhub/explainer/YYYY-MM-DD-{episodeId}/`
-   - Write `{episodeId}.md` from the generated script content
-   - Present the download path in addition to the above summary.
+   **`download` or `both`**: Also save the script file. Generate a topic slug following `shared/config-pattern.md` § Artifact Naming.
+   - If text-only output: save as `{slug}-explainer.md` in cwd (dedup if exists)
+   - If text+video output: create `{slug}-explainer/` folder (dedup if exists), write `script.md` inside
+   - Present the save path in addition to the above summary.
 
 5. **If video requested**: `POST /storybook/episodes/{episodeId}/video` (foreground) → **poll again (background)** using the **exact** bash command below with `run_in_background: true` and `timeout: 600000`. Poll for `videoStatus`, not `processStatus`:
 
@@ -250,14 +250,17 @@ Present:
 消耗积分：{credits}
 ```
 
-**`download` or `both`**: Also download the audio file.
+**`download` or `both`**: Also download the audio file into the `{slug}-explainer/` folder.
 ```bash
-DATE=$(date +%Y-%m-%d)
-JOB_DIR=".listenhub/explainer/${DATE}-{jobId}"
-mkdir -p "$JOB_DIR"
-curl -sS -o "${JOB_DIR}/{jobId}.mp3" "{audioUrl}"
+curl -sS -o "{slug}-explainer/audio.mp3" "{audioUrl}"
 ```
-Present the download path in addition to the above summary.
+Present:
+```
+已保存到当前目录：
+  {slug}-explainer/
+    script.md
+    audio.mp3
+```
 
 ### After Successful Generation
 

--- a/explainer/SKILL.md
+++ b/explainer/SKILL.md
@@ -52,30 +52,36 @@ Follow `shared/config-pattern.md` § API Key Check. If the key is missing, stop 
 
 ## Step 0: Config Setup
 
-Follow `shared/config-pattern.md` Step 0.
+Follow `shared/config-pattern.md` Step 0 (Zero-Question Boot).
 
-**If file doesn't exist** — ask location, then create immediately:
+**If file doesn't exist** — silently create with defaults and proceed:
 ```bash
 mkdir -p ".listenhub/explainer"
 echo '{"outputDir":".listenhub","outputMode":"inline","language":null,"defaultStyle":null,"defaultSpeakers":{}}' > ".listenhub/explainer/config.json"
 CONFIG_PATH=".listenhub/explainer/config.json"
-# (or $HOME/.listenhub/explainer/config.json for global)
+CONFIG=$(cat "$CONFIG_PATH")
 ```
-Then run **Setup Flow** below.
+**Do NOT ask any setup questions.** Proceed directly to the Interaction Flow.
 
-**If file exists** — read config, display summary, and confirm:
+**If file exists** — read config silently and proceed:
+```bash
+CONFIG_PATH=".listenhub/explainer/config.json"
+[ ! -f "$CONFIG_PATH" ] && CONFIG_PATH="$HOME/.listenhub/explainer/config.json"
+CONFIG=$(cat "$CONFIG_PATH")
+```
+
+### Setup Flow (user-initiated reconfigure only)
+
+Only run when the user explicitly asks to reconfigure. Display current settings:
 ```
 当前配置 (explainer)：
   输出方式：{inline / download / both}
   语言偏好：{zh / en / 未设置}
   默认风格：{info / story / 未设置}
-  默认主播：{speakerName / 未设置}
+  默认主播：{speakerName / 使用内置默认}
 ```
-Ask: "使用已保存的配置？" → **确认，直接继续** / **重新配置**
 
-### Setup Flow (first run or reconfigure)
-
-Ask these questions in order, then save all answers to config at once:
+Then ask:
 
 1. **outputMode**: Follow `shared/output-mode.md` § Setup Flow Question.
 
@@ -91,13 +97,10 @@ Ask these questions in order, then save all answers to config at once:
 
 After collecting answers, save immediately:
 ```bash
-# Follow shared/output-mode.md § Save to Config
 NEW_CONFIG=$(echo "$CONFIG" | jq --arg m "$OUTPUT_MODE" '. + {"outputMode": $m}')
 echo "$NEW_CONFIG" > "$CONFIG_PATH"
 CONFIG=$(cat "$CONFIG_PATH")
 ```
-
-Note: `defaultSpeakers` are saved after generation (see After Successful Generation section).
 
 ## Interaction Flow
 
@@ -135,10 +138,11 @@ Options:
 
 ### Step 4: Speaker Selection
 
-Follow `shared/speaker-selection.md` for the full selection flow, including:
-- Default from `config.defaultSpeakers.{language}` (skip step if set)
-- Text table + free-text input
-- Input matching and re-prompt on no match
+Follow `shared/speaker-selection.md`:
+- If `config.defaultSpeakers.{language}` is set → use saved speaker silently
+- If not set → use **built-in default** from `shared/speaker-selection.md` for the language
+- Show the speaker in the confirmation summary (Step 6) — user can change from there if desired
+- Only show the full speaker list if the user explicitly asks to change voice
 
 Only 1 speaker is supported for explainer videos.
 

--- a/image-gen/SKILL.md
+++ b/image-gen/SKILL.md
@@ -254,6 +254,7 @@ echo "$BASE64_DATA" | base64 --decode > output.jpg
 RESPONSE=$(curl -sS -X POST "https://api.labnana.com/openapi/v1/images/generation" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   --max-time 600 \
   -d '{
     "provider": "google",

--- a/image-gen/SKILL.md
+++ b/image-gen/SKILL.md
@@ -35,7 +35,7 @@ Generate AI images using the Labnana API. Supports text prompts with optional re
 - No shell scripts. Construct curl commands from the API reference files listed in Resources
 - Always read `shared/authentication.md` for API key and headers
 - Follow `shared/common-patterns.md` for error handling
-- Image generation uses a **different base URL**: `https://api.labnana.com/openapi/v1`
+- Image generation uses a **different base URL**: `https://api.marswave.ai/openapi/v1`
 - Always read config following `shared/config-pattern.md` before any interaction
 - Output saved to `.listenhub/image-gen/YYYY-MM-DD-{jobId}/` — never `~/Downloads/`
 
@@ -174,7 +174,7 @@ Wait for explicit confirmation before calling the API.
 
 1. **Build request**: Construct JSON with provider, model, prompt, imageConfig, and optional referenceImages (URL-based via `fileData` or base64 via `inlineData`)
 2. **Encode local files** (if base64 mode): For each local file path, encode to base64 and build `inlineData` objects
-3. **Submit**: `POST https://api.labnana.com/openapi/v1/images/generation` with timeout of 600s
+3. **Submit**: `POST https://api.marswave.ai/openapi/v1/images/generation` with timeout of 600s
 4. **Extract image**: Parse base64 data from response
 5. **Decode and present result**
 
@@ -266,7 +266,7 @@ echo "$BASE64_DATA" | base64 --decode > output.jpg
 5. No references
 
 ```bash
-RESPONSE=$(curl -sS -X POST "https://api.labnana.com/openapi/v1/images/generation" \
+RESPONSE=$(curl -sS -X POST "https://api.marswave.ai/openapi/v1/images/generation" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
   --max-time 600 \
@@ -302,7 +302,7 @@ Decode the base64 data per `outputMode` (see `shared/output-mode.md`).
 # Encode local reference image
 BASE64_REF=$(base64 -i /path/to/style-reference.png)
 
-RESPONSE=$(curl -sS -X POST "https://api.labnana.com/openapi/v1/images/generation" \
+RESPONSE=$(curl -sS -X POST "https://api.marswave.ai/openapi/v1/images/generation" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
   --max-time 600 \

--- a/image-gen/SKILL.md
+++ b/image-gen/SKILL.md
@@ -129,14 +129,28 @@ If flash model was selected, also offer: `1:4` (narrow portrait), `4:1` (wide la
 Question: "Any reference images for style guidance?"
 Options:
   - "Yes, I have URL(s)" — Provide reference image URLs
+  - "Yes, I have local file(s)" — Provide local file paths (base64 mode)
   - "No references" — Generate from prompt only
 ```
 
-If yes, collect URLs (comma-separated, max 14). For each URL, infer mimeType from suffix and build:
+**If URL mode**: Collect URLs (comma-separated, max 14). For each URL, infer mimeType from suffix and build:
 ```json
 { "fileData": { "fileUri": "<url>", "mimeType": "<inferred>" } }
 ```
 Suffix mapping: `.jpg`/`.jpeg` → `image/jpeg`, `.png` → `image/png`, `.webp` → `image/webp`, `.gif` → `image/gif`
+
+**If local file (base64) mode**: Collect file paths (comma-separated, max 14). For each file, encode to base64 and infer mimeType from suffix:
+```bash
+# macOS
+BASE64_REF=$(base64 -i /path/to/image.png)
+# Linux
+BASE64_REF=$(base64 -w 0 /path/to/image.png)
+```
+Build:
+```json
+{ "inlineData": { "data": "<base64-encoded>", "mimeType": "<inferred>" } }
+```
+Suffix mapping: `.jpg`/`.jpeg` → `image/jpeg`, `.png` → `image/png`, `.webp` → `image/webp`, `.heic` → `image/heic`, `.heif` → `image/heif`
 
 ### Step 5: Confirm & Generate
 
@@ -149,7 +163,7 @@ Ready to generate image:
   Model: {pro / flash}
   Resolution: {1K / 2K / 4K}
   Aspect ratio: {ratio}
-  References: {yes (N URLs) / no}
+  References: {yes — N URL(s) / yes — N local file(s) / no}
 
   Proceed?
 ```
@@ -158,10 +172,11 @@ Wait for explicit confirmation before calling the API.
 
 ## Workflow
 
-1. **Build request**: Construct JSON with provider, model, prompt, imageConfig, and optional referenceImages
-2. **Submit**: `POST https://api.labnana.com/openapi/v1/images/generation` with timeout of 600s
-3. **Extract image**: Parse base64 data from response
-4. **Decode and present result**
+1. **Build request**: Construct JSON with provider, model, prompt, imageConfig, and optional referenceImages (URL-based via `fileData` or base64 via `inlineData`)
+2. **Encode local files** (if base64 mode): For each local file path, encode to base64 and build `inlineData` objects
+3. **Submit**: `POST https://api.labnana.com/openapi/v1/images/generation` with timeout of 600s
+4. **Extract image**: Parse base64 data from response
+5. **Decode and present result**
 
 Read `OUTPUT_MODE` from config. Follow `shared/output-mode.md` for behavior.
 
@@ -261,6 +276,43 @@ RESPONSE=$(curl -sS -X POST "https://api.labnana.com/openapi/v1/images/generatio
     "prompt": "cyberpunk city at night",
     "imageConfig": {"imageSize": "2K", "aspectRatio": "16:9"}
   }')
+
+BASE64_DATA=$(echo "$RESPONSE" | jq -r '.candidates[0].content.parts[0].inlineData.data // .data')
+JOB_ID=$(date +%s)
+DATE=$(date +%Y-%m-%d)
+JOB_DIR=".listenhub/image-gen/${DATE}-${JOB_ID}"
+mkdir -p "$JOB_DIR"
+echo "$BASE64_DATA" | base64 -D > "${JOB_DIR}/${JOB_ID}.jpg"
+```
+
+Decode the base64 data per `outputMode` (see `shared/output-mode.md`).
+
+### Example 2 — With Local Reference Image (base64)
+
+**User**: "Generate an image in this style" (provides a local file path)
+
+**Agent workflow**:
+1. Ask prompt → "a serene mountain lake at dawn"
+2. Ask model → "pro"
+3. Ask resolution → "2K"
+4. Ask ratio → "16:9"
+5. References → local file → `/path/to/style-reference.png`
+
+```bash
+# Encode local reference image
+BASE64_REF=$(base64 -i /path/to/style-reference.png)
+
+RESPONSE=$(curl -sS -X POST "https://api.labnana.com/openapi/v1/images/generation" \
+  -H "Authorization: Bearer $LISTENHUB_API_KEY" \
+  -H "Content-Type: application/json" \
+  --max-time 600 \
+  -d "{
+    \"provider\": \"google\",
+    \"model\": \"gemini-3-pro-image-preview\",
+    \"prompt\": \"a serene mountain lake at dawn\",
+    \"imageConfig\": {\"imageSize\": \"2K\", \"aspectRatio\": \"16:9\"},
+    \"referenceImages\": [{\"inlineData\": {\"data\": \"$BASE64_REF\", \"mimeType\": \"image/png\"}}]
+  }")
 
 BASE64_DATA=$(echo "$RESPONSE" | jq -r '.candidates[0].content.parts[0].inlineData.data // .data')
 JOB_ID=$(date +%s)

--- a/image-gen/SKILL.md
+++ b/image-gen/SKILL.md
@@ -49,31 +49,38 @@ Follow `shared/config-pattern.md` § API Key Check. If the key is missing, stop 
 
 ## Step 0: Config Setup
 
-Follow `shared/config-pattern.md` Step 0.
+Follow `shared/config-pattern.md` Step 0 (Zero-Question Boot).
 
-**If file doesn't exist** — ask location, then create immediately:
+**If file doesn't exist** — silently create with defaults and proceed:
 ```bash
 mkdir -p ".listenhub/image-gen"
 echo '{"outputDir":".listenhub","outputMode":"inline"}' > ".listenhub/image-gen/config.json"
 CONFIG_PATH=".listenhub/image-gen/config.json"
-# (or $HOME/.listenhub/image-gen/config.json for global)
+CONFIG=$(cat "$CONFIG_PATH")
 ```
-Then run **Setup Flow** below.
+**Do NOT ask any setup questions.** Proceed directly to the Interaction Flow.
 
-**If file exists** — read config, display summary, and confirm:
+**If file exists** — read config silently and proceed:
+```bash
+CONFIG_PATH=".listenhub/image-gen/config.json"
+[ ! -f "$CONFIG_PATH" ] && CONFIG_PATH="$HOME/.listenhub/image-gen/config.json"
+CONFIG=$(cat "$CONFIG_PATH")
+```
+
+### Setup Flow (user-initiated reconfigure only)
+
+Only run when the user explicitly asks to reconfigure. Display current settings:
 ```
 当前配置 (image-gen)：
   输出方式：{inline / download / both}
 ```
-Ask: "使用已保存的配置？" → **确认，直接继续** / **重新配置**
 
-### Setup Flow (first run or reconfigure)
+Then ask:
 
 1. **outputMode**: Follow `shared/output-mode.md` § Setup Flow Question.
 
 Save immediately:
 ```bash
-# Follow shared/output-mode.md § Save to Config
 NEW_CONFIG=$(echo "$CONFIG" | jq --arg m "$OUTPUT_MODE" '. + {"outputMode": $m}')
 echo "$NEW_CONFIG" > "$CONFIG_PATH"
 CONFIG=$(cat "$CONFIG_PATH")

--- a/image-gen/references/prompt-guide.md
+++ b/image-gen/references/prompt-guide.md
@@ -46,10 +46,12 @@ A good image prompt has these elements (in any order):
 Reference images guide the AI on style, not content. Tips:
 
 - Use reference images for style transfer: "generate in this art style"
-- Direct image URLs required (`.jpg`, `.png`, `.webp`, `.gif`)
+- Two modes available:
+  - **URL mode**: Direct image URLs (`.jpg`, `.png`, `.webp`, `.gif`)
+  - **Local file mode**: Provide file paths — the agent encodes them as base64 (`.jpg`, `.png`, `.webp`, `.heic`, `.heif`)
 - Max 14 reference images per request
 - The prompt still controls the content; references control the visual style
-- Recommended image hosts: imgbb.com, sm.ms, postimages.org, imgur.com
+- For URL mode, recommended image hosts: imgbb.com, sm.ms, postimages.org, imgur.com
 
 ## Language Note
 

--- a/podcast/SKILL.md
+++ b/podcast/SKILL.md
@@ -214,7 +214,8 @@ Wait for explicit confirmation before calling any API.
    EPISODE_ID="<id-from-step-1>"
    for i in $(seq 1 30); do
      RESULT=$(curl -sS "https://api.marswave.ai/openapi/v1/podcast/episodes/$EPISODE_ID" \
-       -H "Authorization: Bearer $LISTENHUB_API_KEY" 2>/dev/null)
+       -H "Authorization: Bearer $LISTENHUB_API_KEY" \
+       -H "X-Source: skills" 2>/dev/null)
      STATUS=$(echo "$RESULT" | tr -d '\000-\037\177' | jq -r '.data.processStatus // "pending"')
      case "$STATUS" in
        success|completed) echo "$RESULT"; exit 0 ;;
@@ -312,6 +313,7 @@ echo "$NEW_CONFIG" > "$CONFIG_PATH"
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/podcast/episodes" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   -d '{
     "sources": [{"type": "text", "content": "The latest AI developments"}],
     "speakers": [{"speakerId": "cozy-man-english"}],

--- a/podcast/SKILL.md
+++ b/podcast/SKILL.md
@@ -52,31 +52,37 @@ Follow `shared/config-pattern.md` § API Key Check. If the key is missing, stop 
 
 ## Step 0: Config Setup
 
-Follow `shared/config-pattern.md` Step 0.
+Follow `shared/config-pattern.md` Step 0 (Zero-Question Boot).
 
-**If file doesn't exist** — ask location, then create immediately:
+**If file doesn't exist** — silently create with defaults and proceed:
 ```bash
 mkdir -p ".listenhub/podcast"
-echo '{"outputDir":".listenhub","outputMode":"inline","language":null,"defaultMode":null,"defaultMethod":null,"defaultSpeakers":{}}' > ".listenhub/podcast/config.json"
+echo '{"outputDir":".listenhub","outputMode":"inline","language":null,"defaultMode":null,"defaultMethod":"one-step","defaultSpeakers":{}}' > ".listenhub/podcast/config.json"
 CONFIG_PATH=".listenhub/podcast/config.json"
-# (or $HOME/.listenhub/podcast/config.json for global)
+CONFIG=$(cat "$CONFIG_PATH")
 ```
-Then run **Setup Flow** below.
+**Do NOT ask any setup questions.** Proceed directly to the Interaction Flow.
 
-**If file exists** — read config, display summary, and confirm:
+**If file exists** — read config silently and proceed:
+```bash
+CONFIG_PATH=".listenhub/podcast/config.json"
+[ ! -f "$CONFIG_PATH" ] && CONFIG_PATH="$HOME/.listenhub/podcast/config.json"
+CONFIG=$(cat "$CONFIG_PATH")
+```
+
+### Setup Flow (user-initiated reconfigure only)
+
+Only run when the user explicitly asks to reconfigure. Display current settings:
 ```
 当前配置 (podcast)：
   输出方式：{inline / download / both}
   语言偏好：{zh / en / 未设置}
   默认模式：{quick / deep / debate / 未设置}
-  默认生成方式：{one-step / two-step / 未设置}
-  默认主播：{speakerName(s) / 未设置}
+  默认生成方式：{one-step / two-step}
+  默认主播：{speakerName(s) / 使用内置默认}
 ```
-Ask: "使用已保存的配置？" → **确认，直接继续** / **重新配置**
 
-### Setup Flow (first run or reconfigure)
-
-Ask these questions in order, then save all answers to config at once:
+Then ask these questions in order and save:
 
 1. **outputMode**: Follow `shared/output-mode.md` § Setup Flow Question.
 
@@ -103,8 +109,6 @@ NEW_CONFIG=$(echo "$CONFIG" | jq --arg m "$OUTPUT_MODE" '. + {"outputMode": $m}'
 echo "$NEW_CONFIG" > "$CONFIG_PATH"
 CONFIG=$(cat "$CONFIG_PATH")
 ```
-
-Note: `defaultSpeakers` are saved after generation (see After Successful Generation section).
 
 ## Interaction Flow
 
@@ -154,12 +158,13 @@ Note: Debate mode automatically sets 2 speakers.
 
 ### Step 5: Speaker Selection
 
-Follow `shared/speaker-selection.md` for the full selection flow, including:
-- Default from `config.defaultSpeakers.{language}` (skip step if set)
-- Text table + free-text input
-- Input matching and re-prompt on no match
+Follow `shared/speaker-selection.md`:
+- If `config.defaultSpeakers.{language}` is set → use saved speakers silently
+- If not set → use **built-in defaults** from `shared/speaker-selection.md` (no question asked)
+- Show the speaker(s) in the confirmation summary (Step 8) — user can change from there if desired
+- Only show the full speaker list if the user explicitly asks to change voices
 
-For 2-speaker mode (dialogue/debate): run selection twice (or until both are chosen).
+For 2-speaker mode (dialogue/debate): use Primary + Secondary defaults for the language.
 
 ### Step 6: Reference Materials (optional)
 

--- a/podcast/SKILL.md
+++ b/podcast/SKILL.md
@@ -57,7 +57,7 @@ Follow `shared/config-pattern.md` Step 0 (Zero-Question Boot).
 **If file doesn't exist** — silently create with defaults and proceed:
 ```bash
 mkdir -p ".listenhub/podcast"
-echo '{"outputMode":"inline","language":null,"defaultMode":null,"defaultMethod":"one-step","defaultSpeakers":{}}' > ".listenhub/podcast/config.json"
+echo '{"outputMode":"inline","language":null,"defaultMode":"quick","defaultMethod":"one-step","defaultSpeakers":{}}' > ".listenhub/podcast/config.json"
 CONFIG_PATH=".listenhub/podcast/config.json"
 CONFIG=$(cat "$CONFIG_PATH")
 ```
@@ -123,83 +123,61 @@ CONFIG=$(cat "$CONFIG_PATH")
 
 ## Interaction Flow
 
-### Step 1: Topic / Content Source
+### Step 1: Topic + Reference Materials
 
-Free text input. Ask the user:
+Ask topic and optional reference materials **together in a single question** using AskUserQuestion with two sub-questions, or a single free-text prompt:
 
-> What topic or content would you like to turn into a podcast?
+> What topic would you like to turn into a podcast? If you have reference materials (URLs or text), include them here too.
 
-Accept: topic description, URL, or pasted text.
+Accept: topic description, URL(s), pasted text, or any combination.
+
+Examples of valid input:
+- "AI developments in 2026"
+- "https://example.com/article — discuss this"
+- "The pros and cons of remote work. Reference: https://study.com/remote-work-2026"
 
 ### Step 2: Mode
 
-If `config.defaultMode` is set, pre-fill and show in summary — skip this question.
-Otherwise ask:
+**Default: "quick"** — skip this question unless:
+- `config.defaultMode` is set to something else → use that value silently
+- User explicitly mentioned a mode keyword in Step 1 (e.g. "deep dive", "debate", "in depth") → infer mode from intent
 
-```
-Question: "What podcast generation mode?"
-Options:
-  - "Quick" — Short, concise overview (~5 min)
-  - "Deep" — Thorough analysis with more detail (~10-15 min)
-  - "Debate" — Two speakers with opposing views (requires 2 speakers)
-```
+Only ask this question if the user's intent is ambiguous AND no default is configured. In most cases, just use "quick".
 
 ### Step 3: Language
 
-If `config.language` is set, pre-fill and show in summary — skip this question.
-Otherwise ask:
+**Default: match the user's interaction language.** Detect from the language the user used in Step 1:
+- If the user wrote in Chinese → `zh`
+- If the user wrote in English → `en`
+- If `config.language` is set → use that value
 
-```
-Question: "What language?"
-Options:
-  - "Chinese (zh)" — Content in Mandarin Chinese
-  - "English (en)" — Content in English
-```
+**Never ask this question.** Always infer silently. Show in the confirmation summary so the user can override if needed.
 
 ### Step 4: Speaker Count
 
-```
-Question: "How many speakers?"
-Options:
-  - "1 speaker (solo)" — Monologue style
-  - "2 speakers (dialogue)" — Conversation style
-```
+**Default: 2 speakers (dialogue)** — the most common and engaging format.
 
-Note: Debate mode automatically sets 2 speakers.
+Skip this question. Debate mode requires 2 speakers. For quick/deep, default to 2 speakers as well.
+
+Only use 1 speaker if the user explicitly requests a monologue or solo format.
 
 ### Step 5: Speaker Selection
 
 Follow `shared/speaker-selection.md`:
 - If `config.defaultSpeakers.{language}` is set → use saved speakers silently
 - If not set → use **built-in defaults** from `shared/speaker-selection.md` (no question asked)
-- Show the speaker(s) in the confirmation summary (Step 8) — user can change from there if desired
+- Show the speaker(s) in the confirmation summary — user can change from there if desired
 - Only show the full speaker list if the user explicitly asks to change voices
 
 For 2-speaker mode (dialogue/debate): use Primary + Secondary defaults for the language.
 
-### Step 6: Reference Materials (optional)
+### Step 6: Generation Method
 
-```
-Question: "Any reference materials to include?"
-Options:
-  - "Yes, URL(s)" — Provide URLs to analyze
-  - "Yes, text" — Paste reference text
-  - "No references" — Generate from topic alone
-```
+**Default: "one-step"** — skip this question unless:
+- `config.defaultMethod` is set → use that value silently
+- User explicitly asks to review text first → use "two-step"
 
-### Step 7: Generation Method
-
-If `config.defaultMethod` is set, pre-fill and show in summary — skip this question.
-Otherwise ask:
-
-```
-Question: "How would you like to generate?"
-Options:
-  - "One step (recommended)" — Generate text + audio together, faster
-  - "Two steps (review first)" — Generate text, review/edit, then generate audio
-```
-
-### Step 8: Confirm & Generate
+### Step 7: Confirm & Generate
 
 Summarize all choices:
 
@@ -210,13 +188,13 @@ Ready to generate podcast:
   Mode: {mode}
   Language: {language}
   Speakers: {speaker name(s)}
-  References: {yes/no}
+  References: {yes/no + brief description}
   Method: {one-step/two-step}
 
   Proceed?
 ```
 
-Wait for explicit confirmation before calling any API.
+Wait for explicit confirmation before calling any API. The user can adjust any parameter here before confirming.
 
 ## Workflow
 
@@ -324,13 +302,9 @@ echo "$NEW_CONFIG" > "$CONFIG_PATH"
 **User**: "Make a podcast about the latest AI developments"
 
 **Agent workflow**:
-1. Detect: podcast request, topic = "latest AI developments"
-2. Ask mode → user picks "Deep"
-3. Ask language → "English"
-4. Ask speakers → 1 speaker
-5. Fetch speakers list, user picks "cozy-man-english"
-6. No references
-7. One-step generation
+1. Detect: podcast request, topic = "latest AI developments", no references
+2. Infer: mode = "quick" (default), language = "en" (user wrote in English), 2 speakers (default), one-step (default)
+3. Show confirmation summary → user confirms
 
 ```bash
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/podcast/episodes" \

--- a/podcast/SKILL.md
+++ b/podcast/SKILL.md
@@ -39,7 +39,7 @@ Generate podcast episodes with 1-2 AI speakers discussing a topic. Supports quic
 - Never fabricate API endpoints or parameters
 - Always read config following `shared/config-pattern.md` before any interaction
 - Always follow `shared/speaker-selection.md` for speaker selection (text table + free-text input)
-- Never save files to `~/Downloads/` — use `.listenhub/podcast/` from config
+- Never save files to `~/Downloads/` or `.listenhub/` — save artifacts to the current working directory with friendly topic-based names (see `shared/config-pattern.md` § Artifact Naming)
 
 <HARD-GATE>
 Use the AskUserQuestion tool for every multiple-choice step — do NOT print options as plain text. Ask one question at a time. Wait for the user's answer before proceeding to the next step. After all parameters are collected, summarize the choices and ask the user to confirm. Do NOT call any generation API until the user has explicitly confirmed.
@@ -57,7 +57,7 @@ Follow `shared/config-pattern.md` Step 0 (Zero-Question Boot).
 **If file doesn't exist** — silently create with defaults and proceed:
 ```bash
 mkdir -p ".listenhub/podcast"
-echo '{"outputDir":".listenhub","outputMode":"inline","language":null,"defaultMode":null,"defaultMethod":"one-step","defaultSpeakers":{}}' > ".listenhub/podcast/config.json"
+echo '{"outputMode":"inline","language":null,"defaultMode":null,"defaultMethod":"one-step","defaultSpeakers":{}}' > ".listenhub/podcast/config.json"
 CONFIG_PATH=".listenhub/podcast/config.json"
 CONFIG=$(cat "$CONFIG_PATH")
 ```
@@ -257,32 +257,39 @@ Wait for explicit confirmation before calling any API.
    消耗积分：{credits}
    ```
 
-   **`download` or `both`**: Also download the file.
+   **`download` or `both`**: Also download the file. Generate a topic slug following `shared/config-pattern.md` § Artifact Naming.
    ```bash
-   DATE=$(date +%Y-%m-%d)
-   JOB_DIR=".listenhub/podcast/${DATE}-{episodeId}"
-   mkdir -p "$JOB_DIR"
-   curl -sS -o "${JOB_DIR}/{episodeId}.mp3" "{audioUrl}"
+   SLUG="{topic-slug}"  # e.g. "ai-developments"
+   NAME="${SLUG}-podcast.mp3"
+   # Dedup: if file exists, append -2, -3, etc.
+   BASE="${NAME%.*}"; EXT="${NAME##*.}"; i=2
+   while [ -e "$NAME" ]; do NAME="${BASE}-${i}.${EXT}"; i=$((i+1)); done
+   curl -sS -o "$NAME" "{audioUrl}"
    ```
-   Present the download path in addition to the above summary.
+   Present:
+   ```
+   已保存到当前目录：
+     {NAME}
+   ```
 5. Offer to show transcript or provide download URL on request
 
 ### Two-Step Generation
 
 1. **Step 1 — Submit text (foreground)**: `POST /podcast/episodes/text-content` → extract `episodeId`
 2. **Poll text (background)**: Use the exact `jq`-based polling loop above (substitute endpoint `podcast/episodes/text-content/{episodeId}` if needed), with `run_in_background: true` and `timeout: 600000`
-3. When notified, **save draft to config output dir**:
-   - Create `.listenhub/podcast/YYYY-MM-DD-{episodeId}/`
-   - Write `{episodeId}-draft.md` (human-readable: `**{speakerName}**: {content}` per line)
-   - Write `{episodeId}-draft.json` (raw `scripts` array)
+3. When notified, **save draft to a topic-based folder in cwd**:
+   - Generate a topic slug following `shared/config-pattern.md` § Artifact Naming
+   - Create `{slug}-podcast/` folder (dedup if exists)
+   - Write `draft.md` (human-readable: `**{speakerName}**: {content}` per line)
+   - Write `draft.json` (raw `scripts` array)
    - Present the draft location and content preview
 4. **STOP**: Present the draft and wait for explicit user approval
 5. **Step 2 — Submit audio (foreground, after approval)**:
    - No changes: `POST /podcast/episodes/{episodeId}/audio` with `{}`
    - With edits: `POST /podcast/episodes/{episodeId}/audio` with modified `{scripts: [...]}`
 6. **Poll audio (background)**: Same exact `jq`-based loop, `run_in_background: true`, `timeout: 600000`
-7. When notified, **download audio to same folder**:
-   - `curl -sS -o .listenhub/podcast/{dir}/{episodeId}.mp3 {audioUrl}`
+7. When notified, **download audio to the same folder**:
+   - `curl -sS -o {slug}-podcast/podcast.mp3 {audioUrl}`
    - Present final result (same format as one-step, folder now has draft + final files)
 
 ### After Successful Generation

--- a/podcast/SKILL.md
+++ b/podcast/SKILL.md
@@ -35,7 +35,7 @@ Generate podcast episodes with 1-2 AI speakers discussing a topic. Supports quic
 - No shell scripts. Construct curl commands from the API reference files listed in Resources
 - Always read `shared/authentication.md` for API key and headers
 - Follow `shared/common-patterns.md` for polling, errors, and interaction patterns
-- Never hardcode speaker IDs — always fetch from the speakers API
+- Never hardcode speaker IDs in API calls — use built-in defaults from `shared/speaker-selection.md` as fallback only; fetch from the speakers API when the user wants to change voice
 - Never fabricate API endpoints or parameters
 - Always read config following `shared/config-pattern.md` before any interaction
 - Always follow `shared/speaker-selection.md` for speaker selection (text table + free-text input)
@@ -104,8 +104,19 @@ Then ask these questions in order and save:
 
 After collecting answers, save immediately:
 ```bash
-# Follow shared/output-mode.md § Save to Config
 NEW_CONFIG=$(echo "$CONFIG" | jq --arg m "$OUTPUT_MODE" '. + {"outputMode": $m}')
+# Save language if user chose one (not "每次手动选择")
+if [ "$LANGUAGE" != "null" ]; then
+  NEW_CONFIG=$(echo "$NEW_CONFIG" | jq --arg lang "$LANGUAGE" '. + {"language": $lang}')
+fi
+# Save mode if user chose one
+if [ "$MODE" != "null" ]; then
+  NEW_CONFIG=$(echo "$NEW_CONFIG" | jq --arg mode "$MODE" '. + {"defaultMode": $mode}')
+fi
+# Save method if user chose one
+if [ "$METHOD" != "null" ]; then
+  NEW_CONFIG=$(echo "$NEW_CONFIG" | jq --arg method "$METHOD" '. + {"defaultMethod": $method}')
+fi
 echo "$NEW_CONFIG" > "$CONFIG_PATH"
 CONFIG=$(cat "$CONFIG_PATH")
 ```

--- a/shared/api-content-extract.md
+++ b/shared/api-content-extract.md
@@ -25,6 +25,7 @@ Create a content extraction task for a URL. Returns a `taskId` for polling.
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/content/extract" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   -d '{
     "source": {
       "type": "url",
@@ -39,6 +40,7 @@ curl -sS -X POST "https://api.marswave.ai/openapi/v1/content/extract" \
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/content/extract" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   -d '{
     "source": {
       "type": "url",
@@ -87,7 +89,8 @@ Get extraction task status and results.
 
 ```bash
 curl -sS "https://api.marswave.ai/openapi/v1/content/extract/69a7dac700cf95938f86d9bb" \
-  -H "Authorization: Bearer $LISTENHUB_API_KEY"
+  -H "Authorization: Bearer $LISTENHUB_API_KEY" \
+  -H "X-Source: skills"
 ```
 
 **Response (processing):**

--- a/shared/api-image.md
+++ b/shared/api-image.md
@@ -38,24 +38,49 @@ Generate an AI image from a text prompt. Synchronous — returns base64-encoded 
 
 **referenceImages format:**
 
+Each item must have either `fileData` (URL) or `inlineData` (base64), not both. You can mix URL and base64 items in the same array.
+
+*URL-based reference:*
+
 ```json
-[
-  {
-    "fileData": {
-      "fileUri": "https://example.com/photo.png",
-      "mimeType": "image/png"
-    }
+{
+  "fileData": {
+    "fileUri": "https://example.com/photo.png",
+    "mimeType": "image/png"
   }
-]
+}
 ```
 
 Infer `mimeType` from URL suffix: `.jpg`/`.jpeg` → `image/jpeg`, `.png` → `image/png`, `.webp` → `image/webp`, `.gif` → `image/gif`
+
+*Base64 reference (inline):*
+
+```json
+{
+  "inlineData": {
+    "data": "<base64-encoded-image>",
+    "mimeType": "image/png"
+  }
+}
+```
+
+Supported mimeTypes: `image/png`, `image/jpeg`, `image/webp`, `image/heic`, `image/heif`
+
+To encode a local file as base64:
+
+```bash
+# macOS
+BASE64_REF=$(base64 -i /path/to/image.png)
+
+# Linux
+BASE64_REF=$(base64 -w 0 /path/to/image.png)
+```
 
 **Constraints:**
 - Use `--max-time 600` (generation can take up to 10 minutes)
 - On 429 (rate limit): wait 15s and retry. Max 3 retries.
 
-**curl:**
+**curl (text-only):**
 
 ```bash
 RESPONSE=$(curl -sS -X POST "https://api.labnana.com/openapi/v1/images/generation" \
@@ -68,6 +93,24 @@ RESPONSE=$(curl -sS -X POST "https://api.labnana.com/openapi/v1/images/generatio
     "prompt": "cyberpunk city at night, neon lights, highly detailed",
     "imageConfig": {"imageSize": "2K", "aspectRatio": "16:9"}
   }')
+```
+
+**curl (with base64 reference image):**
+
+```bash
+BASE64_REF=$(base64 -i /path/to/reference.png)
+
+RESPONSE=$(curl -sS -X POST "https://api.labnana.com/openapi/v1/images/generation" \
+  -H "Authorization: Bearer $LISTENHUB_API_KEY" \
+  -H "Content-Type: application/json" \
+  --max-time 600 \
+  -d "{
+    \"provider\": \"google\",
+    \"model\": \"gemini-3-pro-image-preview\",
+    \"prompt\": \"cyberpunk city at night\",
+    \"imageConfig\": {\"imageSize\": \"2K\", \"aspectRatio\": \"16:9\"},
+    \"referenceImages\": [{\"inlineData\": {\"data\": \"$BASE64_REF\", \"mimeType\": \"image/png\"}}]
+  }")
 ```
 
 **Response:**

--- a/shared/api-image.md
+++ b/shared/api-image.md
@@ -1,6 +1,6 @@
-# ListenHub API — Image Generation (Labnana)
+# ListenHub API — Image Generation
 
-**Base URL**: `https://api.labnana.com/openapi/v1`
+**Base URL**: `https://api.marswave.ai/openapi/v1`
 **Authentication**: Bearer `$LISTENHUB_API_KEY` (same key, different host)
 
 ## POST /images/generation
@@ -83,7 +83,7 @@ BASE64_REF=$(base64 -w 0 /path/to/image.png)
 **curl (text-only):**
 
 ```bash
-RESPONSE=$(curl -sS -X POST "https://api.labnana.com/openapi/v1/images/generation" \
+RESPONSE=$(curl -sS -X POST "https://api.marswave.ai/openapi/v1/images/generation" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
   --max-time 600 \
@@ -100,7 +100,7 @@ RESPONSE=$(curl -sS -X POST "https://api.labnana.com/openapi/v1/images/generatio
 ```bash
 BASE64_REF=$(base64 -i /path/to/reference.png)
 
-RESPONSE=$(curl -sS -X POST "https://api.labnana.com/openapi/v1/images/generation" \
+RESPONSE=$(curl -sS -X POST "https://api.marswave.ai/openapi/v1/images/generation" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
   --max-time 600 \

--- a/shared/api-image.md
+++ b/shared/api-image.md
@@ -61,6 +61,7 @@ Infer `mimeType` from URL suffix: `.jpg`/`.jpeg` → `image/jpeg`, `.png` → `i
 RESPONSE=$(curl -sS -X POST "https://api.labnana.com/openapi/v1/images/generation" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   --max-time 600 \
   -d '{
     "provider": "google",

--- a/shared/api-podcast.md
+++ b/shared/api-podcast.md
@@ -37,6 +37,7 @@ Create a podcast episode.
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/podcast/episodes" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   -d '{
     "query": "The future of AI development",
     "sources": [{"type": "text", "content": "Reference material about AI trends"}],
@@ -72,7 +73,8 @@ Get podcast episode details and status.
 
 ```bash
 curl -sS "https://api.marswave.ai/openapi/v1/podcast/episodes/688c9a27348f001e707ba331" \
-  -H "Authorization: Bearer $LISTENHUB_API_KEY"
+  -H "Authorization: Bearer $LISTENHUB_API_KEY" \
+  -H "X-Source: skills"
 ```
 
 **Response:**

--- a/shared/api-speakers.md
+++ b/shared/api-speakers.md
@@ -18,7 +18,8 @@ Get available voice speakers, optionally filtered by language.
 
 ```bash
 curl -sS "https://api.marswave.ai/openapi/v1/speakers/list?language=en" \
-  -H "Authorization: Bearer $LISTENHUB_API_KEY"
+  -H "Authorization: Bearer $LISTENHUB_API_KEY" \
+  -H "X-Source: skills"
 ```
 
 **Response:**

--- a/shared/api-storybook.md
+++ b/shared/api-storybook.md
@@ -35,6 +35,7 @@ Create a storybook episode. Returns an `episodeId` immediately; generation runs 
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/storybook/episodes" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   -d '{
     "sources": [{"type": "text", "content": "The history of the Roman Empire"}],
     "speakers": [{"speakerId": "cozy-man-english"}],
@@ -71,7 +72,8 @@ Get storybook episode status and result.
 
 ```bash
 curl -sS "https://api.marswave.ai/openapi/v1/storybook/episodes/688c9a27348f001e707ba331" \
-  -H "Authorization: Bearer $LISTENHUB_API_KEY"
+  -H "Authorization: Bearer $LISTENHUB_API_KEY" \
+  -H "X-Source: skills"
 ```
 
 **Response:**
@@ -142,7 +144,8 @@ Trigger video generation for a completed storybook episode. Video combines the p
 
 ```bash
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/storybook/episodes/688c9a27348f001e707ba331/video" \
-  -H "Authorization: Bearer $LISTENHUB_API_KEY"
+  -H "Authorization: Bearer $LISTENHUB_API_KEY" \
+  -H "X-Source: skills"
 ```
 
 **Response:**

--- a/shared/api-tts.md
+++ b/shared/api-tts.md
@@ -23,6 +23,7 @@ Low-latency single-voice TTS. Returns a **streaming binary MP3** — not JSON.
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/tts" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   -d '{
     "input": "Hello, welcome to ListenHub.",
     "voice": "EN-Man-General-01"
@@ -57,6 +58,7 @@ Multi-speaker script-to-audio. Each script segment uses a different voice. Retur
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/speech" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   -d '{
     "scripts": [
       {"content": "Welcome everyone.", "speakerId": "EN-Man-General-01"},

--- a/shared/authentication.md
+++ b/shared/authentication.md
@@ -25,7 +25,7 @@ source ~/.zshrc
 | Service | Base URL |
 |---------|----------|
 | ListenHub API | `https://api.marswave.ai/openapi/v1` |
-| Image Generation (Labnana) | `https://api.labnana.com/openapi/v1` |
+| Image Generation | `https://api.marswave.ai/openapi/v1` |
 | Staging (ListenHub) | `https://staging-api.marswave.ai/openapi/v1` |
 
 ## Required Headers

--- a/shared/authentication.md
+++ b/shared/authentication.md
@@ -35,7 +35,10 @@ Every request must include:
 ```
 Authorization: Bearer $LISTENHUB_API_KEY
 Content-Type: application/json
+X-Source: skills
 ```
+
+The `X-Source: skills` header identifies requests as coming from Claude Code skills (CLI tool), distinguishing them from `openapi` (web) or other sources on the server side.
 
 ## curl Template
 
@@ -43,6 +46,7 @@ Content-Type: application/json
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/{endpoint}" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   -d '{ ... }'
 ```
 

--- a/shared/common-patterns.md
+++ b/shared/common-patterns.md
@@ -25,6 +25,7 @@ All polling MUST run in the background using Bash `run_in_background: true`. Thi
 RESPONSE=$(curl -sS -X POST "https://api.marswave.ai/openapi/v1/podcast/episodes" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   -d '{ ... }')
 
 EPISODE_ID=$(echo "$RESPONSE" | jq -r '.data.episodeId')
@@ -42,7 +43,8 @@ Run this as a **separate Bash call** with `run_in_background: true`:
 EPISODE_ID="<id-from-step-1>"
 for i in $(seq 1 30); do
   RESULT=$(curl -sS "https://api.marswave.ai/openapi/v1/podcast/episodes/$EPISODE_ID" \
-    -H "Authorization: Bearer $LISTENHUB_API_KEY" 2>/dev/null)
+    -H "Authorization: Bearer $LISTENHUB_API_KEY" \
+    -H "X-Source: skills" 2>/dev/null)
 
   STATUS=$(echo "$RESULT" | tr -d '\000-\037\177' | jq -r '.data.processStatus // "pending"')
 
@@ -137,6 +139,7 @@ ENDJSON
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/podcast/episodes" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   -d @/tmp/lh-request.json
 ```
 

--- a/shared/config-pattern.md
+++ b/shared/config-pattern.md
@@ -4,24 +4,38 @@ Reusable pattern for per-skill config lookup, creation, and update.
 
 ## API Key Check
 
-Run this **before Step 0** in every skill that requires `LISTENHUB_API_KEY`. Hard gate — if missing, stop immediately and do not proceed.
+Run this **before Step 0** in every skill that requires `LISTENHUB_API_KEY`.
 
 ```bash
 [ -z "$LISTENHUB_API_KEY" ] && echo "MISSING" || echo "OK"
 ```
 
-**If `OK`**: proceed to Step 0.
+**If `OK`**: proceed to Step 0 silently. Do NOT display or confirm the key.
 
-**If `MISSING`**: tell the user that `LISTENHUB_API_KEY` is not set, and show the steps below to configure it. Then stop — do NOT proceed to Step 0 or any interaction flow.
+**If `MISSING`**: run the interactive setup below. Do NOT stop — guide the user through configuration and then continue.
 
-### Missing Key Message
+### Interactive Key Setup
 
-Tell the user:
-- `LISTENHUB_API_KEY` is not set
-- Get an API key at https://listenhub.ai/settings/api-keys (Pro plan required)
-- Add `export LISTENHUB_API_KEY="lh_sk_..."` to `~/.zshrc` (macOS) or `~/.bashrc` (Linux)
-- Run `source ~/.zshrc` to reload
-- Re-run this skill after configuring
+1. Tell the user:
+   > `LISTENHUB_API_KEY` 未配置。请前往 https://listenhub.ai/settings/api-keys 获取 API Key（需要 Pro 订阅）。
+
+2. Use `AskUserQuestion` to collect the key:
+   > 请粘贴你的 API Key（以 `lh_sk_` 开头）：
+
+3. Validate format — must start with `lh_sk_`. If not, re-prompt.
+
+4. Write to shell profile and source:
+   ```bash
+   echo '' >> ~/.zshrc
+   echo 'export LISTENHUB_API_KEY="lh_sk_..."' >> ~/.zshrc
+   source ~/.zshrc
+   ```
+   On Linux, use `~/.bashrc` instead.
+
+5. Confirm to the user:
+   > API Key 已保存到 `~/.zshrc`，后续会话无需重复配置。
+
+6. **Continue** — proceed to Step 0 and the skill's Interaction Flow. Do NOT ask the user to re-run.
 
 ## Config Location
 

--- a/shared/config-pattern.md
+++ b/shared/config-pattern.md
@@ -31,57 +31,48 @@ Each skill stores config at:
 .listenhub/{skill}/config.json
 ```
 
-## Step 0: Config Setup
+## Step 0: Config Setup (Zero-Question Boot)
 
-Run before any interaction in every skill. Three possible states:
+Run before any interaction in every skill. The goal is **zero questions on first run** — create config silently with sensible defaults and proceed directly to the task.
 
 ### State A — File Doesn't Exist (first run)
 
-Use `AskUserQuestion`:
-```
-Question: "ListenHub 配置文件存在哪里？"
-Options:
-  - "当前目录" — {CWD}/.listenhub/{skill}/config.json（仅此项目）
-  - "全局" — ~/.listenhub/{skill}/config.json（所有项目共用）
-```
-
-Then create the directory and write the skill's initial defaults **immediately**:
+**Do NOT ask any questions.** Silently create the config in the current directory with the skill's default values:
 
 ```bash
-# 当前目录:
 mkdir -p ".listenhub/{skill}"
 echo '{...skill initial defaults...}' > ".listenhub/{skill}/config.json"
 CONFIG_PATH=".listenhub/{skill}/config.json"
-
-# 全局:
-mkdir -p "$HOME/.listenhub/{skill}"
-echo '{...skill initial defaults...}' > "$HOME/.listenhub/{skill}/config.json"
-CONFIG_PATH="$HOME/.listenhub/{skill}/config.json"
+CONFIG=$(cat "$CONFIG_PATH")
 ```
 
-Then run the skill's **Setup Flow** to collect preferences and save them.
+Then proceed directly to the skill's **Interaction Flow** (skip Setup Flow entirely).
 
 ### State B — File Exists
 
-Read the config:
+Read the config silently and proceed:
+
 ```bash
 CONFIG_PATH=".listenhub/{skill}/config.json"
 [ ! -f "$CONFIG_PATH" ] && CONFIG_PATH="$HOME/.listenhub/{skill}/config.json"
 CONFIG=$(cat "$CONFIG_PATH")
 ```
 
-Display the current settings in a readable summary (skill-specific format), then ask:
+**Do NOT display config summary or ask for confirmation.** Proceed directly to the skill's Interaction Flow.
 
-```
-Question: "使用已保存的配置？"
-Options:
-  - "确认，直接继续" — use saved config as-is, skip Setup Flow
-  - "重新配置" — run Setup Flow again and overwrite saved values
-```
+### Reconfigure (user-initiated only)
+
+If the user explicitly asks to reconfigure (e.g., "reconfigure", "change settings", "重新配置"), then:
+
+1. Display the current settings in a readable summary (skill-specific format)
+2. Run the skill's **Setup Flow** to collect new preferences
+3. Save updated values
+
+This is the **only** time Setup Flow questions are asked.
 
 ## Setup Flow
 
-Each skill defines its own Setup Flow — questions to collect preferences on first run or reconfigure. After answers are collected, **save immediately** using the merge pattern:
+Each skill defines its own Setup Flow — questions to collect preferences when the user explicitly requests reconfiguration. After answers are collected, **save immediately** using the merge pattern:
 
 ```bash
 NEW_CONFIG=$(echo "$CONFIG" | jq '. + {"key": "value"}')

--- a/shared/config-pattern.md
+++ b/shared/config-pattern.md
@@ -112,22 +112,40 @@ NEW_CONFIG=$(echo "$CONFIG" | jq '. + {"language": "zh", "defaultMode": "deep"}'
 echo "$NEW_CONFIG" > "$CONFIG_PATH"
 ```
 
-## Artifact Directory
+## Artifact Naming
 
-After a job completes, create a dated subfolder and download artifacts:
+Artifacts are saved to the **current working directory** with friendly, topic-based names.
+
+### Slug Generation
+
+After the topic/title is confirmed, generate a short filesystem-safe slug:
+
+- Summarize the topic into 2-5 words
+- Lowercase, hyphens for spaces, keep CJK characters
+- Strip characters unsafe for filenames: `/ \ : * ? " < > |`
+- Examples: `ai-developments`, `量子计算入门`, `react-hooks-tutorial`
+
+### Dedup
+
+Before saving, check for naming conflicts:
 
 ```bash
-DATE=$(date +%Y-%m-%d)
-JOB_DIR=".listenhub/{skill}/${DATE}-{jobId}"
-mkdir -p "$JOB_DIR"
+# For single files:
+NAME="{slug}-podcast.mp3"
+BASE="${NAME%.*}"; EXT="${NAME##*.}"
+i=2; while [ -e "$NAME" ]; do NAME="${BASE}-${i}.${EXT}"; i=$((i+1)); done
 
-# Download each artifact
-curl -sS -o "${JOB_DIR}/{jobId}.mp3" "{audioUrl}"
-curl -sS -o "${JOB_DIR}/{jobId}.md"  "{transcriptUrl}"  # if applicable
+# For folders:
+DIR="{slug}-podcast"
+i=2; while [ -d "$DIR" ]; do DIR="{slug}-podcast-${i}"; i=$((i+1)); done
 ```
 
-File naming: `{jobId}.{ext}` inside `YYYY-MM-DD-{jobId}/`.
-Draft files (two-step mode): `{jobId}-draft.md`, `{jobId}-draft.json`.
+### Single-File vs Folder
+
+- **Single artifact** (one mp3, one md): save as `{slug}{suffix}.{ext}` in cwd
+- **Multiple artifacts** (draft + final, script + audio): create `{slug}{suffix}/` folder in cwd
+
+Each skill defines its own suffix and structure — see individual skill files.
 
 ## Output Mode
 

--- a/shared/output-mode.md
+++ b/shared/output-mode.md
@@ -63,19 +63,14 @@ Show the result directly in the conversation. Do NOT save to `.listenhub/`.
 
 ### `download`
 
-Save to `.listenhub/{skill}/YYYY-MM-DD-{jobId}/` and show the local file path. This is the previous `autoDownload: true` behavior.
+Save to the **current working directory** with a friendly topic-based name. Follow `shared/config-pattern.md` § Artifact Naming for slug generation and dedup.
 
-```bash
-DATE=$(date +%Y-%m-%d)
-JOB_DIR=".listenhub/{skill}/${DATE}-{jobId}"
-mkdir -p "$JOB_DIR"
-curl -sS -o "${JOB_DIR}/{jobId}.mp3" "{audioUrl}"
-```
+Each skill defines its own naming convention (see individual SKILL.md files).
 
 Present:
 ```
-已下载到 .listenhub/{skill}/{YYYY-MM-DD}-{jobId}/：
-  {jobId}.mp3
+已保存到当前目录：
+  {filename or folder}/
 ```
 
 ### `both`

--- a/shared/output-mode.md
+++ b/shared/output-mode.md
@@ -30,7 +30,7 @@ OUTPUT_MODE=$(echo "$CONFIG" | jq -r '.outputMode // "inline"')
 
 ## Setup Flow Question
 
-Replace the "自动下载？" question with:
+Only asked during user-initiated reconfigure (not on first run — first run uses `"inline"` as default):
 
 ```
 Question: "输出方式？"

--- a/shared/speaker-selection.md
+++ b/shared/speaker-selection.md
@@ -1,25 +1,47 @@
 # Speaker Selection Guide
 
+## Built-in Default Speakers
+
+When no user preference is saved, use these built-in defaults. This eliminates the need to ask about speakers on first use.
+
+| Language | Role | Name | Speaker ID |
+|----------|------|------|------------|
+| `zh` | Primary (male) | 原野 | `CN-Man-Beijing-V2` |
+| `zh` | Secondary (female) | 高晴 | `gaoqing3-bfb5c88a` |
+| `en` | Primary (male) | Mars | `cozy-man-english` |
+| `en` | Secondary (female) | Mia | `travel-girl-english` |
+
+### How to use defaults
+
+1. Check `config.defaultSpeakers.{language}` first
+2. If not set, use the built-in defaults from the table above
+3. Only show speaker selection UI if the user explicitly asks to change voices
+
+**Single speaker**: use Primary for the language.
+**Two speakers**: use Primary + Secondary for the language.
+
 ## Fetching Speakers
 
-Always call the speakers API before presenting options:
+Always call the speakers API before presenting options (when user requests to change voice):
 
 ```
 GET /speakers/list?language={language}
 ```
 
-Never hardcode speaker IDs — the available list may change.
+Never hardcode speaker IDs in API calls — use the defaults above only as fallback when no user preference exists.
 
 ## Speaker Properties
 
 Each speaker has:
-- **name**: Display name (e.g., "Yuanye")
+- **name**: Display name (e.g., "Mars")
 - **speakerId**: Technical ID to pass to API (e.g., "cozy-man-english")
 - **gender**: `male` or `female`
 - **language**: `zh` or `en`
 - **demoAudioUrl**: Preview audio URL
 
-## Presenting Options
+## Presenting Options (user-initiated only)
+
+Only show the speaker selection UI when the user explicitly asks to change voices (e.g., "change voice", "换个声音", "pick a different speaker").
 
 ### Step 1 — Output the full text table
 
@@ -30,15 +52,15 @@ Available voices (N total):
 
 | # | Name        | Gender | ID                  |
 |---|-------------|--------|---------------------|
-| 1 | Yuanye      | male   | cozy-man-english    |
-| 2 | Travel Girl | female | travel-girl-english |
-| 3 | Alex        | male   | alex-en             |
-| …                                              |
+| 1 | Mars        | male   | cozy-man-english    |
+| 2 | Mia         | female | travel-girl-english |
+| 3 | Leo         | male   | leo-9328b6d2        |
+| ...                                             |
 
 Type a name, number, or ID to select.
 ```
 
-Adapt the table header language to match the user's language (Chinese users → Chinese headers, English users → English headers).
+Adapt the table header language to match the user's language (Chinese users -> Chinese headers, English users -> English headers).
 
 Do NOT use `AskUserQuestion` for speaker selection — just show the table and wait for free-text input.
 
@@ -49,7 +71,7 @@ Do NOT use `AskUserQuestion` for speaker selection — just show the table and w
 | Number (e.g. "3") | Match by row index in the table |
 | Exact `speakerId` | Exact string match |
 | Name text | Case-insensitive substring match on `name` |
-| No match | Reply in user's language: "「{input}」not found, please try again" and re-prompt |
+| No match | Reply in user's language: "{input} not found, please try again" and re-prompt |
 
 If multiple speakers match the name substring, print the matches as a short table and ask again.
 
@@ -57,16 +79,17 @@ If multiple speakers match the name substring, print the matches as a short tabl
 
 If the config has `defaultSpeakers.{language}` set:
 1. Skip the selection step
-2. Show the saved speaker(s) in the confirmation summary
-3. User can change from the summary if desired
+2. Use the saved speaker(s) directly
+3. Show the speaker(s) in the confirmation summary — user can change from the summary if desired
 
-If no default is saved:
-1. Fetch speaker list for the selected language
-2. Show the full table and wait for free-text input
+If no default is saved in config:
+1. Use the **built-in defaults** from the table above
+2. Show the speaker(s) in the confirmation summary — user can change if desired
+3. Do NOT show the full speaker list or ask for selection
 
 ## After Selection — Persist to Config
 
-After the user confirms, update `defaultSpeakers.{language}` in the skill's config:
+After the user explicitly selects a voice (not when using defaults), update `defaultSpeakers.{language}` in the skill's config:
 
 ```bash
 NEW_CONFIG=$(echo "$CONFIG" | jq \
@@ -76,4 +99,4 @@ NEW_CONFIG=$(echo "$CONFIG" | jq \
 echo "$NEW_CONFIG" > "$CONFIG_PATH"
 ```
 
-For 2-speaker mode: array holds two IDs. If only one is saved, ask for the second.
+For 2-speaker mode: array holds two IDs. If only one is saved, use the built-in secondary default for the language.

--- a/tts/SKILL.md
+++ b/tts/SKILL.md
@@ -40,7 +40,7 @@ Convert text into natural-sounding speech audio. Two paths:
 - Never hardcode speaker IDs in API calls — use built-in defaults from `shared/speaker-selection.md` as fallback only; fetch from the speakers API when the user wants to change voice
 - Always read config following `shared/config-pattern.md` before any interaction
 - Always follow `shared/speaker-selection.md` for speaker selection (text table + free-text input)
-- Never save files to `~/Downloads/` or `/tmp/` as primary output — use `.listenhub/tts/`
+- Never save files to `~/Downloads/` or `/tmp/` as primary output — save artifacts to the current working directory with friendly topic-based names (see `shared/config-pattern.md` § Artifact Naming)
 
 <HARD-GATE>
 Use the AskUserQuestion tool for every multiple-choice step — do NOT print options as plain text. Ask one question at a time. Wait for the user's answer before proceeding to the next step. After all parameters are collected, summarize the choices and ask the user to confirm. Do NOT call any generation API until the user has explicitly confirmed.
@@ -73,7 +73,7 @@ Follow `shared/config-pattern.md` Step 0 (Zero-Question Boot).
 **If file doesn't exist** — silently create with defaults and proceed:
 ```bash
 mkdir -p ".listenhub/tts"
-echo '{"outputDir":".listenhub","outputMode":"inline","language":null,"defaultSpeakers":{}}' > ".listenhub/tts/config.json"
+echo '{"outputMode":"inline","language":null,"defaultSpeakers":{}}' > ".listenhub/tts/config.json"
 CONFIG_PATH=".listenhub/tts/config.json"
 CONFIG=$(cat "$CONFIG_PATH")
 ```
@@ -186,25 +186,26 @@ Present:
 Audio generated!
 ```
 
-**`download` or `both`**:
+**`download` or `both`**: Generate a topic slug from the text content following `shared/config-pattern.md` § Artifact Naming.
 ```bash
-JOB_ID=$(date +%s)
-DATE=$(date +%Y-%m-%d)
-JOB_DIR=".listenhub/tts/${DATE}-${JOB_ID}"
-mkdir -p "$JOB_DIR"
+SLUG="{topic-slug}"  # e.g. "server-maintenance-notice"
+NAME="${SLUG}.mp3"
+# Dedup: if file exists, append -2, -3, etc.
+BASE="${NAME%.*}"; EXT="${NAME##*.}"; i=2
+while [ -e "$NAME" ]; do NAME="${BASE}-${i}.${EXT}"; i=$((i+1)); done
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/tts" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
   -H "X-Source: skills" \
   -d '{"input": "...", "voice": "..."}' \
-  --output "${JOB_DIR}/${JOB_ID}.mp3"
+  --output "$NAME"
 ```
 Present:
 ```
 Audio generated!
 
-已下载到 .listenhub/tts/{YYYY-MM-DD}-{jobId}/：
-  {jobId}.mp3
+已保存到当前目录：
+  {NAME}
 ```
 
 ---
@@ -296,21 +297,26 @@ Audio generated!
 消耗积分：{credits}
 ```
 
-**`download` or `both`**: Also download the file.
+**`download` or `both`**: Also download the file. Generate a topic slug following `shared/config-pattern.md` § Artifact Naming.
 ```bash
-DATE=$(date +%Y-%m-%d)
-JOB_DIR=".listenhub/tts/${DATE}-{jobId}"
-mkdir -p "$JOB_DIR"
-curl -sS -o "${JOB_DIR}/{jobId}.mp3" "{audioUrl}"
+SLUG="{topic-slug}"  # e.g. "welcome-dialogue"
+NAME="${SLUG}.mp3"
+# Dedup: if file exists, append -2, -3, etc.
+BASE="${NAME%.*}"; EXT="${NAME##*.}"; i=2
+while [ -e "$NAME" ]; do NAME="${BASE}-${i}.${EXT}"; i=$((i+1)); done
+curl -sS -o "$NAME" "{audioUrl}"
 ```
-Present the download path in addition to the above summary.
+Present:
+```
+已保存到当前目录：
+  {NAME}
+```
 
 ---
 
 ## Updating Config
 
 When saving preferences, merge into `.listenhub/tts/config.json` — do not overwrite unchanged keys.
-Follow the merge pattern in `shared/config-pattern.md`.
 
 - Quick voice: set `defaultSpeakers.{language}[0]` to the selected `speakerId`
 - Script voices: set `defaultSpeakers.{language}` to the full array assigned this session

--- a/tts/SKILL.md
+++ b/tts/SKILL.md
@@ -151,6 +151,7 @@ Proceed?
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/tts" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   -d '{"input": "...", "voice": "..."}' \
   --output /tmp/tts-output.mp3
 ```
@@ -167,6 +168,7 @@ JOB_ID=$(date +%s)
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/tts" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   -d '{"input": "...", "voice": "..."}' \
   --output /tmp/tts-${JOB_ID}.mp3
 ```
@@ -186,6 +188,7 @@ mkdir -p "$JOB_DIR"
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/tts" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   -d '{"input": "...", "voice": "..."}' \
   --output "${JOB_DIR}/${JOB_ID}.mp3"
 ```
@@ -263,6 +266,7 @@ ENDJSON
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/speech" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   -d @/tmp/lh-speech-request.json
 
 rm /tmp/lh-speech-request.json

--- a/tts/SKILL.md
+++ b/tts/SKILL.md
@@ -37,7 +37,7 @@ Convert text into natural-sounding speech audio. Two paths:
 - No shell scripts. Construct curl commands from the API reference files listed in Resources
 - Always read `shared/authentication.md` for API key and headers
 - Follow `shared/common-patterns.md` for errors and interaction patterns
-- Never hardcode speaker IDs — always fetch from the speakers API
+- Never hardcode speaker IDs in API calls — use built-in defaults from `shared/speaker-selection.md` as fallback only; fetch from the speakers API when the user wants to change voice
 - Always read config following `shared/config-pattern.md` before any interaction
 - Always follow `shared/speaker-selection.md` for speaker selection (text table + free-text input)
 - Never save files to `~/Downloads/` or `/tmp/` as primary output — use `.listenhub/tts/`
@@ -108,6 +108,10 @@ Then ask:
 After collecting answers, save immediately:
 ```bash
 NEW_CONFIG=$(echo "$CONFIG" | jq --arg m "$OUTPUT_MODE" '. + {"outputMode": $m}')
+# Save language if user chose one (not "每次手动选择")
+if [ "$LANGUAGE" != "null" ]; then
+  NEW_CONFIG=$(echo "$NEW_CONFIG" | jq --arg lang "$LANGUAGE" '. + {"language": $lang}')
+fi
 echo "$NEW_CONFIG" > "$CONFIG_PATH"
 CONFIG=$(cat "$CONFIG_PATH")
 ```

--- a/tts/SKILL.md
+++ b/tts/SKILL.md
@@ -68,29 +68,35 @@ Follow `shared/config-pattern.md` § API Key Check. If the key is missing, stop 
 
 ### Step 0: Config Setup
 
-Follow `shared/config-pattern.md` Step 0.
+Follow `shared/config-pattern.md` Step 0 (Zero-Question Boot).
 
-**If file doesn't exist** — ask location, then create immediately:
+**If file doesn't exist** — silently create with defaults and proceed:
 ```bash
 mkdir -p ".listenhub/tts"
 echo '{"outputDir":".listenhub","outputMode":"inline","language":null,"defaultSpeakers":{}}' > ".listenhub/tts/config.json"
 CONFIG_PATH=".listenhub/tts/config.json"
-# (or $HOME/.listenhub/tts/config.json for global)
+CONFIG=$(cat "$CONFIG_PATH")
 ```
-Then run **Setup Flow** below.
+**Do NOT ask any setup questions.** Proceed directly to the Interaction Flow.
 
-**If file exists** — read config, display summary, and confirm:
+**If file exists** — read config silently and proceed:
+```bash
+CONFIG_PATH=".listenhub/tts/config.json"
+[ ! -f "$CONFIG_PATH" ] && CONFIG_PATH="$HOME/.listenhub/tts/config.json"
+CONFIG=$(cat "$CONFIG_PATH")
+```
+
+### Setup Flow (user-initiated reconfigure only)
+
+Only run when the user explicitly asks to reconfigure. Display current settings:
 ```
 当前配置 (tts)：
   输出方式：{inline / download / both}
   语言偏好：{zh / en / 未设置}
-  默认主播：{speakerName / 未设置}
+  默认主播：{speakerName / 使用内置默认}
 ```
-Ask: "使用已保存的配置？" → **确认，直接继续** / **重新配置**
 
-### Setup Flow (first run or reconfigure)
-
-Ask these questions in order, then save all answers to config at once:
+Then ask:
 
 1. **outputMode**: Follow `shared/output-mode.md` § Setup Flow Question.
 
@@ -101,16 +107,10 @@ Ask these questions in order, then save all answers to config at once:
 
 After collecting answers, save immediately:
 ```bash
-# Save outputMode; only update language if user picked one
-# Follow shared/output-mode.md § Save to Config
 NEW_CONFIG=$(echo "$CONFIG" | jq --arg m "$OUTPUT_MODE" '. + {"outputMode": $m}')
-# If language was chosen (not "每次手动选择"):
-NEW_CONFIG=$(echo "$NEW_CONFIG" | jq --arg lang "zh" '. + {"language": $lang}')
 echo "$NEW_CONFIG" > "$CONFIG_PATH"
 CONFIG=$(cat "$CONFIG_PATH")
 ```
-
-Note: `defaultSpeakers` are saved after speaker selection in Step 3 — not here.
 
 ### Quick Mode — `POST /v1/tts`
 
@@ -123,9 +123,12 @@ Get the text to convert. If the user hasn't provided it, ask:
 **Step 2: Determine voice**
 
 - If `config.defaultSpeakers.{language}[0]` is set → use it silently (skip to Step 4)
-- Otherwise: `GET /speakers/list?language={detected-language}`, then follow `shared/speaker-selection.md` (text table + free-text input)
+- If not set → use the **built-in default** from `shared/speaker-selection.md` for the detected language (skip to Step 4)
+- Only show speaker selection if the user explicitly asks to change voice
 
 **Step 3: Save preference**
+
+After the user explicitly selects a new voice (not when using defaults):
 
 ```
 Question: "Save {voice name} as your default voice for {language}?"
@@ -217,7 +220,8 @@ Determine whether the user already has a scripts array:
 For each unique character in the script:
 
 - If `config.defaultSpeakers.{language}` has saved voices → auto-assign silently (one per character in order)
-- Otherwise: fetch `GET /speakers/list?language={detected-language}` and follow `shared/speaker-selection.md` for each character
+- If not set → use **built-in defaults** from `shared/speaker-selection.md` (Primary for first character, Secondary for second)
+- Only show speaker selection if the user explicitly asks to change voices
 
 **Step 3: Save preferences**
 


### PR DESCRIPTION
## Summary
- Update image-gen skill to support local file reference images via base64 encoding (`inlineData`), alongside existing URL-based (`fileData`) mode
- Update `shared/api-image.md` with base64 reference format documentation, supported MIME types, and encoding instructions
- Update `image-gen/references/prompt-guide.md` to document both URL and local file reference modes

## Related
- Closes MARS-3591
- Companion to marswaveai/listenhub-api-server#609

## Test plan
- [ ] Verify image-gen skill correctly handles local file path as reference image
- [ ] Verify base64 encoding works on both macOS and Linux

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that expand the image-gen skill and API docs to describe base64-encoded local reference images; no runtime code paths are modified.
> 
> **Overview**
> Adds a second reference-image input mode for `image-gen`: alongside URL-based `fileData`, the skill/docs now describe accepting local file paths that are base64-encoded into `inlineData` items.
> 
> Updates the `shared/api-image.md` referenceImages spec to allow `fileData` or `inlineData` (including supported mime types and encoding snippets), and refreshes examples/guides to show the new local-file workflow and confirmation messaging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e59c253356398b9f8f31f07977d9c54ff439bbbe. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->