### PR TITLE
feat: zero-question onboarding for skills

### DIFF
--- a/asr/SKILL.md
+++ b/asr/SKILL.md
@@ -67,29 +67,32 @@ If `coli` is missing, stop here and do not proceed.
 
 ### Step 0: Config Setup
 
-Follow `shared/config-pattern.md` Step 0.
+Follow `shared/config-pattern.md` Step 0 (Zero-Question Boot).
 
-Initial defaults:
+**If file doesn't exist** — silently create with defaults and proceed:
 ```bash
-# 当前目录:
 mkdir -p ".listenhub/asr"
 echo '{"model":"sensevoice","polish":true}' > ".listenhub/asr/config.json"
 CONFIG_PATH=".listenhub/asr/config.json"
+CONFIG=$(cat "$CONFIG_PATH")
+```
+**Do NOT ask any setup questions.** Proceed directly to the Interaction Flow with sensible defaults (sensevoice model, polish enabled).
 
-# 全局:
-mkdir -p "$HOME/.listenhub/asr"
-echo '{"model":"sensevoice","polish":true}' > "$HOME/.listenhub/asr/config.json"
-CONFIG_PATH="$HOME/.listenhub/asr/config.json"
+**If file exists** — read config silently and proceed:
+```bash
+CONFIG_PATH=".listenhub/asr/config.json"
+[ ! -f "$CONFIG_PATH" ] && CONFIG_PATH="$HOME/.listenhub/asr/config.json"
+CONFIG=$(cat "$CONFIG_PATH")
 ```
 
-Config summary display:
+### Setup Flow (user-initiated reconfigure only)
+
+Only run when the user explicitly asks to reconfigure. Display current settings:
 ```
 当前配置 (asr)：
   模型：sensevoice / whisper-tiny.en
   润色：开启 / 关闭
 ```
-
-### Setup Flow (first run or reconfigure)
 
 Ask in order:
 

--- a/content-parser/SKILL.md
+++ b/content-parser/SKILL.md
@@ -48,25 +48,33 @@ Follow `shared/config-pattern.md` § API Key Check. If the key is missing, stop 
 
 ## Step 0: Config Setup
 
-Follow `shared/config-pattern.md` Step 0.
+Follow `shared/config-pattern.md` Step 0 (Zero-Question Boot).
 
-**If file doesn't exist** — ask location, then create immediately:
+**If file doesn't exist** — silently create with defaults and proceed:
 ```bash
 mkdir -p ".listenhub/content-parser"
 echo '{"autoDownload":true}' > ".listenhub/content-parser/config.json"
 CONFIG_PATH=".listenhub/content-parser/config.json"
-# (or $HOME/.listenhub/content-parser/config.json for global)
+CONFIG=$(cat "$CONFIG_PATH")
 ```
-Then run **Setup Flow** below.
+**Do NOT ask any setup questions.** Proceed directly to the Interaction Flow.
 
-**If file exists** — read config, display summary, and confirm:
+**If file exists** — read config silently and proceed:
+```bash
+CONFIG_PATH=".listenhub/content-parser/config.json"
+[ ! -f "$CONFIG_PATH" ] && CONFIG_PATH="$HOME/.listenhub/content-parser/config.json"
+CONFIG=$(cat "$CONFIG_PATH")
+```
+
+### Setup Flow (user-initiated reconfigure only)
+
+Only run when the user explicitly asks to reconfigure. Display current settings:
 ```
 当前配置 (content-parser)：
   自动下载：{是 / 否}
 ```
-Ask: "使用已保存的配置？" → **确认，直接继续** / **重新配置**
 
-### Setup Flow (first run or reconfigure)
+Then ask:
 
 1. **autoDownload**: "自动保存提取的内容到当前目录？"
    - "是（推荐）" → `autoDownload: true`

--- a/explainer/SKILL.md
+++ b/explainer/SKILL.md
@@ -52,30 +52,36 @@ Follow `shared/config-pattern.md` § API Key Check. If the key is missing, stop 
 
 ## Step 0: Config Setup
 
-Follow `shared/config-pattern.md` Step 0.
+Follow `shared/config-pattern.md` Step 0 (Zero-Question Boot).
 
-**If file doesn't exist** — ask location, then create immediately:
+**If file doesn't exist** — silently create with defaults and proceed:
 ```bash
 mkdir -p ".listenhub/explainer"
 echo '{"outputDir":".listenhub","outputMode":"inline","language":null,"defaultStyle":null,"defaultSpeakers":{}}' > ".listenhub/explainer/config.json"
 CONFIG_PATH=".listenhub/explainer/config.json"
-# (or $HOME/.listenhub/explainer/config.json for global)
+CONFIG=$(cat "$CONFIG_PATH")
 ```
-Then run **Setup Flow** below.
+**Do NOT ask any setup questions.** Proceed directly to the Interaction Flow.
 
-**If file exists** — read config, display summary, and confirm:
+**If file exists** — read config silently and proceed:
+```bash
+CONFIG_PATH=".listenhub/explainer/config.json"
+[ ! -f "$CONFIG_PATH" ] && CONFIG_PATH="$HOME/.listenhub/explainer/config.json"
+CONFIG=$(cat "$CONFIG_PATH")
+```
+
+### Setup Flow (user-initiated reconfigure only)
+
+Only run when the user explicitly asks to reconfigure. Display current settings:
 ```
 当前配置 (explainer)：
   输出方式：{inline / download / both}
   语言偏好：{zh / en / 未设置}
   默认风格：{info / story / 未设置}
-  默认主播：{speakerName / 未设置}
+  默认主播：{speakerName / 使用内置默认}
 ```
-Ask: "使用已保存的配置？" → **确认，直接继续** / **重新配置**
 
-### Setup Flow (first run or reconfigure)
-
-Ask these questions in order, then save all answers to config at once:
+Then ask:
 
 1. **outputMode**: Follow `shared/output-mode.md` § Setup Flow Question.
 
@@ -91,13 +97,10 @@ Ask these questions in order, then save all answers to config at once:
 
 After collecting answers, save immediately:
 ```bash
-# Follow shared/output-mode.md § Save to Config
 NEW_CONFIG=$(echo "$CONFIG" | jq --arg m "$OUTPUT_MODE" '. + {"outputMode": $m}')
 echo "$NEW_CONFIG" > "$CONFIG_PATH"
 CONFIG=$(cat "$CONFIG_PATH")
 ```
-
-Note: `defaultSpeakers` are saved after generation (see After Successful Generation section).
 
 ## Interaction Flow
 
@@ -135,10 +138,11 @@ Options:
 
 ### Step 4: Speaker Selection
 
-Follow `shared/speaker-selection.md` for the full selection flow, including:
-- Default from `config.defaultSpeakers.{language}` (skip step if set)
-- Text table + free-text input
-- Input matching and re-prompt on no match
+Follow `shared/speaker-selection.md`:
+- If `config.defaultSpeakers.{language}` is set → use saved speaker silently
+- If not set → use **built-in default** from `shared/speaker-selection.md` for the language
+- Show the speaker in the confirmation summary (Step 6) — user can change from there if desired
+- Only show the full speaker list if the user explicitly asks to change voice
 
 Only 1 speaker is supported for explainer videos.
 

--- a/image-gen/SKILL.md
+++ b/image-gen/SKILL.md
@@ -49,31 +49,38 @@ Follow `shared/config-pattern.md` § API Key Check. If the key is missing, stop 
 
 ## Step 0: Config Setup
 
-Follow `shared/config-pattern.md` Step 0.
+Follow `shared/config-pattern.md` Step 0 (Zero-Question Boot).
 
-**If file doesn't exist** — ask location, then create immediately:
+**If file doesn't exist** — silently create with defaults and proceed:
 ```bash
 mkdir -p ".listenhub/image-gen"
 echo '{"outputDir":".listenhub","outputMode":"inline"}' > ".listenhub/image-gen/config.json"
 CONFIG_PATH=".listenhub/image-gen/config.json"
-# (or $HOME/.listenhub/image-gen/config.json for global)
+CONFIG=$(cat "$CONFIG_PATH")
 ```
-Then run **Setup Flow** below.
+**Do NOT ask any setup questions.** Proceed directly to the Interaction Flow.
 
-**If file exists** — read config, display summary, and confirm:
+**If file exists** — read config silently and proceed:
+```bash
+CONFIG_PATH=".listenhub/image-gen/config.json"
+[ ! -f "$CONFIG_PATH" ] && CONFIG_PATH="$HOME/.listenhub/image-gen/config.json"
+CONFIG=$(cat "$CONFIG_PATH")
+```
+
+### Setup Flow (user-initiated reconfigure only)
+
+Only run when the user explicitly asks to reconfigure. Display current settings:
 ```
 当前配置 (image-gen)：
   输出方式：{inline / download / both}
 ```
-Ask: "使用已保存的配置？" → **确认，直接继续** / **重新配置**
 
-### Setup Flow (first run or reconfigure)
+Then ask:
 
 1. **outputMode**: Follow `shared/output-mode.md` § Setup Flow Question.
 
 Save immediately:
 ```bash
-# Follow shared/output-mode.md § Save to Config
 NEW_CONFIG=$(echo "$CONFIG" | jq --arg m "$OUTPUT_MODE" '. + {"outputMode": $m}')
 echo "$NEW_CONFIG" > "$CONFIG_PATH"
 CONFIG=$(cat "$CONFIG_PATH")

--- a/podcast/SKILL.md
+++ b/podcast/SKILL.md
@@ -52,31 +52,37 @@ Follow `shared/config-pattern.md` § API Key Check. If the key is missing, stop 
 
 ## Step 0: Config Setup
 
-Follow `shared/config-pattern.md` Step 0.
+Follow `shared/config-pattern.md` Step 0 (Zero-Question Boot).
 
-**If file doesn't exist** — ask location, then create immediately:
+**If file doesn't exist** — silently create with defaults and proceed:
 ```bash
 mkdir -p ".listenhub/podcast"
-echo '{"outputDir":".listenhub","outputMode":"inline","language":null,"defaultMode":null,"defaultMethod":null,"defaultSpeakers":{}}' > ".listenhub/podcast/config.json"
+echo '{"outputDir":".listenhub","outputMode":"inline","language":null,"defaultMode":null,"defaultMethod":"one-step","defaultSpeakers":{}}' > ".listenhub/podcast/config.json"
 CONFIG_PATH=".listenhub/podcast/config.json"
-# (or $HOME/.listenhub/podcast/config.json for global)
+CONFIG=$(cat "$CONFIG_PATH")
 ```
-Then run **Setup Flow** below.
+**Do NOT ask any setup questions.** Proceed directly to the Interaction Flow.
 
-**If file exists** — read config, display summary, and confirm:
+**If file exists** — read config silently and proceed:
+```bash
+CONFIG_PATH=".listenhub/podcast/config.json"
+[ ! -f "$CONFIG_PATH" ] && CONFIG_PATH="$HOME/.listenhub/podcast/config.json"
+CONFIG=$(cat "$CONFIG_PATH")
+```
+
+### Setup Flow (user-initiated reconfigure only)
+
+Only run when the user explicitly asks to reconfigure. Display current settings:
 ```
 当前配置 (podcast)：
   输出方式：{inline / download / both}
   语言偏好：{zh / en / 未设置}
   默认模式：{quick / deep / debate / 未设置}
-  默认生成方式：{one-step / two-step / 未设置}
-  默认主播：{speakerName(s) / 未设置}
+  默认生成方式：{one-step / two-step}
+  默认主播：{speakerName(s) / 使用内置默认}
 ```
-Ask: "使用已保存的配置？" → **确认，直接继续** / **重新配置**
 
-### Setup Flow (first run or reconfigure)
-
-Ask these questions in order, then save all answers to config at once:
+Then ask these questions in order and save:
 
 1. **outputMode**: Follow `shared/output-mode.md` § Setup Flow Question.
 
@@ -103,8 +109,6 @@ NEW_CONFIG=$(echo "$CONFIG" | jq --arg m "$OUTPUT_MODE" '. + {"outputMode": $m}'
 echo "$NEW_CONFIG" > "$CONFIG_PATH"
 CONFIG=$(cat "$CONFIG_PATH")
 ```
-
-Note: `defaultSpeakers` are saved after generation (see After Successful Generation section).
 
 ## Interaction Flow
 
@@ -154,12 +158,13 @@ Note: Debate mode automatically sets 2 speakers.
 
 ### Step 5: Speaker Selection
 
-Follow `shared/speaker-selection.md` for the full selection flow, including:
-- Default from `config.defaultSpeakers.{language}` (skip step if set)
-- Text table + free-text input
-- Input matching and re-prompt on no match
+Follow `shared/speaker-selection.md`:
+- If `config.defaultSpeakers.{language}` is set → use saved speakers silently
+- If not set → use **built-in defaults** from `shared/speaker-selection.md` (no question asked)
+- Show the speaker(s) in the confirmation summary (Step 8) — user can change from there if desired
+- Only show the full speaker list if the user explicitly asks to change voices
 
-For 2-speaker mode (dialogue/debate): run selection twice (or until both are chosen).
+For 2-speaker mode (dialogue/debate): use Primary + Secondary defaults for the language.
 
 ### Step 6: Reference Materials (optional)
 

--- a/shared/config-pattern.md
+++ b/shared/config-pattern.md
@@ -31,57 +31,48 @@ Each skill stores config at:
 .listenhub/{skill}/config.json
 ```
 
-## Step 0: Config Setup
+## Step 0: Config Setup (Zero-Question Boot)
 
-Run before any interaction in every skill. Three possible states:
+Run before any interaction in every skill. The goal is **zero questions on first run** — create config silently with sensible defaults and proceed directly to the task.
 
 ### State A — File Doesn't Exist (first run)
 
-Use `AskUserQuestion`:
-```
-Question: "ListenHub 配置文件存在哪里？"
-Options:
-  - "当前目录" — {CWD}/.listenhub/{skill}/config.json（仅此项目）
-  - "全局" — ~/.listenhub/{skill}/config.json（所有项目共用）
-```
-
-Then create the directory and write the skill's initial defaults **immediately**:
+**Do NOT ask any questions.** Silently create the config in the current directory with the skill's default values:
 
 ```bash
-# 当前目录:
 mkdir -p ".listenhub/{skill}"
 echo '{...skill initial defaults...}' > ".listenhub/{skill}/config.json"
 CONFIG_PATH=".listenhub/{skill}/config.json"
-
-# 全局:
-mkdir -p "$HOME/.listenhub/{skill}"
-echo '{...skill initial defaults...}' > "$HOME/.listenhub/{skill}/config.json"
-CONFIG_PATH="$HOME/.listenhub/{skill}/config.json"
+CONFIG=$(cat "$CONFIG_PATH")
 ```
 
-Then run the skill's **Setup Flow** to collect preferences and save them.
+Then proceed directly to the skill's **Interaction Flow** (skip Setup Flow entirely).
 
 ### State B — File Exists
 
-Read the config:
+Read the config silently and proceed:
+
 ```bash
 CONFIG_PATH=".listenhub/{skill}/config.json"
 [ ! -f "$CONFIG_PATH" ] && CONFIG_PATH="$HOME/.listenhub/{skill}/config.json"
 CONFIG=$(cat "$CONFIG_PATH")
 ```
 
-Display the current settings in a readable summary (skill-specific format), then ask:
+**Do NOT display config summary or ask for confirmation.** Proceed directly to the skill's Interaction Flow.
 
-```
-Question: "使用已保存的配置？"
-Options:
-  - "确认，直接继续" — use saved config as-is, skip Setup Flow
-  - "重新配置" — run Setup Flow again and overwrite saved values
-```
+### Reconfigure (user-initiated only)
+
+If the user explicitly asks to reconfigure (e.g., "reconfigure", "change settings", "重新配置"), then:
+
+1. Display the current settings in a readable summary (skill-specific format)
+2. Run the skill's **Setup Flow** to collect new preferences
+3. Save updated values
+
+This is the **only** time Setup Flow questions are asked.
 
 ## Setup Flow
 
-Each skill defines its own Setup Flow — questions to collect preferences on first run or reconfigure. After answers are collected, **save immediately** using the merge pattern:
+Each skill defines its own Setup Flow — questions to collect preferences when the user explicitly requests reconfiguration. After answers are collected, **save immediately** using the merge pattern:
 
 ```bash
 NEW_CONFIG=$(echo "$CONFIG" | jq '. + {"key": "value"}')

--- a/shared/output-mode.md
+++ b/shared/output-mode.md
@@ -30,7 +30,7 @@ OUTPUT_MODE=$(echo "$CONFIG" | jq -r '.outputMode // "inline"')
 
 ## Setup Flow Question
 
-Replace the "自动下载？" question with:
+Only asked during user-initiated reconfigure (not on first run — first run uses `"inline"` as default):
 
 ```
 Question: "输出方式？"

--- a/shared/speaker-selection.md
+++ b/shared/speaker-selection.md
@@ -1,25 +1,47 @@
 # Speaker Selection Guide
 
+## Built-in Default Speakers
+
+When no user preference is saved, use these built-in defaults. This eliminates the need to ask about speakers on first use.
+
+| Language | Role | Name | Speaker ID |
+|----------|------|------|------------|
+| `zh` | Primary (male) | 原野 | `CN-Man-Beijing-V2` |
+| `zh` | Secondary (female) | 高晴 | `gaoqing3-bfb5c88a` |
+| `en` | Primary (male) | Mars | `cozy-man-english` |
+| `en` | Secondary (female) | Mia | `travel-girl-english` |
+
+### How to use defaults
+
+1. Check `config.defaultSpeakers.{language}` first
+2. If not set, use the built-in defaults from the table above
+3. Only show speaker selection UI if the user explicitly asks to change voices
+
+**Single speaker**: use Primary for the language.
+**Two speakers**: use Primary + Secondary for the language.
+
 ## Fetching Speakers
 
-Always call the speakers API before presenting options:
+Always call the speakers API before presenting options (when user requests to change voice):
 
 ```
 GET /speakers/list?language={language}
 ```
 
-Never hardcode speaker IDs — the available list may change.
+Never hardcode speaker IDs in API calls — use the defaults above only as fallback when no user preference exists.
 
 ## Speaker Properties
 
 Each speaker has:
-- **name**: Display name (e.g., "Yuanye")
+- **name**: Display name (e.g., "Mars")
 - **speakerId**: Technical ID to pass to API (e.g., "cozy-man-english")
 - **gender**: `male` or `female`
 - **language**: `zh` or `en`
 - **demoAudioUrl**: Preview audio URL
 
-## Presenting Options
+## Presenting Options (user-initiated only)
+
+Only show the speaker selection UI when the user explicitly asks to change voices (e.g., "change voice", "换个声音", "pick a different speaker").
 
 ### Step 1 — Output the full text table
 
@@ -30,15 +52,15 @@ Available voices (N total):
 
 | # | Name        | Gender | ID                  |
 |---|-------------|--------|---------------------|
-| 1 | Yuanye      | male   | cozy-man-english    |
-| 2 | Travel Girl | female | travel-girl-english |
-| 3 | Alex        | male   | alex-en             |
-| …                                              |
+| 1 | Mars        | male   | cozy-man-english    |
+| 2 | Mia         | female | travel-girl-english |
+| 3 | Leo         | male   | leo-9328b6d2        |
+| ...                                             |
 
 Type a name, number, or ID to select.
 ```
 
-Adapt the table header language to match the user's language (Chinese users → Chinese headers, English users → English headers).
+Adapt the table header language to match the user's language (Chinese users -> Chinese headers, English users -> English headers).
 
 Do NOT use `AskUserQuestion` for speaker selection — just show the table and wait for free-text input.
 
@@ -49,7 +71,7 @@ Do NOT use `AskUserQuestion` for speaker selection — just show the table and w
 | Number (e.g. "3") | Match by row index in the table |
 | Exact `speakerId` | Exact string match |
 | Name text | Case-insensitive substring match on `name` |
-| No match | Reply in user's language: "「{input}」not found, please try again" and re-prompt |
+| No match | Reply in user's language: "{input} not found, please try again" and re-prompt |
 
 If multiple speakers match the name substring, print the matches as a short table and ask again.
 
@@ -57,16 +79,17 @@ If multiple speakers match the name substring, print the matches as a short tabl
 
 If the config has `defaultSpeakers.{language}` set:
 1. Skip the selection step
-2. Show the saved speaker(s) in the confirmation summary
-3. User can change from the summary if desired
+2. Use the saved speaker(s) directly
+3. Show the speaker(s) in the confirmation summary — user can change from the summary if desired
 
-If no default is saved:
-1. Fetch speaker list for the selected language
-2. Show the full table and wait for free-text input
+If no default is saved in config:
+1. Use the **built-in defaults** from the table above
+2. Show the speaker(s) in the confirmation summary — user can change if desired
+3. Do NOT show the full speaker list or ask for selection
 
 ## After Selection — Persist to Config
 
-After the user confirms, update `defaultSpeakers.{language}` in the skill's config:
+After the user explicitly selects a voice (not when using defaults), update `defaultSpeakers.{language}` in the skill's config:
 
 ```bash
 NEW_CONFIG=$(echo "$CONFIG" | jq \
@@ -76,4 +99,4 @@ NEW_CONFIG=$(echo "$CONFIG" | jq \
 echo "$NEW_CONFIG" > "$CONFIG_PATH"
 ```
 
-For 2-speaker mode: array holds two IDs. If only one is saved, ask for the second.
+For 2-speaker mode: array holds two IDs. If only one is saved, use the built-in secondary default for the language.

--- a/tts/SKILL.md
+++ b/tts/SKILL.md
@@ -68,29 +68,35 @@ Follow `shared/config-pattern.md` § API Key Check. If the key is missing, stop 
 
 ### Step 0: Config Setup
 
-Follow `shared/config-pattern.md` Step 0.
+Follow `shared/config-pattern.md` Step 0 (Zero-Question Boot).
 
-**If file doesn't exist** — ask location, then create immediately:
+**If file doesn't exist** — silently create with defaults and proceed:
 ```bash
 mkdir -p ".listenhub/tts"
 echo '{"outputDir":".listenhub","outputMode":"inline","language":null,"defaultSpeakers":{}}' > ".listenhub/tts/config.json"
 CONFIG_PATH=".listenhub/tts/config.json"
-# (or $HOME/.listenhub/tts/config.json for global)
+CONFIG=$(cat "$CONFIG_PATH")
 ```
-Then run **Setup Flow** below.
+**Do NOT ask any setup questions.** Proceed directly to the Interaction Flow.
 
-**If file exists** — read config, display summary, and confirm:
+**If file exists** — read config silently and proceed:
+```bash
+CONFIG_PATH=".listenhub/tts/config.json"
+[ ! -f "$CONFIG_PATH" ] && CONFIG_PATH="$HOME/.listenhub/tts/config.json"
+CONFIG=$(cat "$CONFIG_PATH")
+```
+
+### Setup Flow (user-initiated reconfigure only)
+
+Only run when the user explicitly asks to reconfigure. Display current settings:
 ```
 当前配置 (tts)：
   输出方式：{inline / download / both}
   语言偏好：{zh / en / 未设置}
-  默认主播：{speakerName / 未设置}
+  默认主播：{speakerName / 使用内置默认}
 ```
-Ask: "使用已保存的配置？" → **确认，直接继续** / **重新配置**
 
-### Setup Flow (first run or reconfigure)
-
-Ask these questions in order, then save all answers to config at once:
+Then ask:
 
 1. **outputMode**: Follow `shared/output-mode.md` § Setup Flow Question.
 
@@ -101,16 +107,10 @@ Ask these questions in order, then save all answers to config at once:
 
 After collecting answers, save immediately:
 ```bash
-# Save outputMode; only update language if user picked one
-# Follow shared/output-mode.md § Save to Config
 NEW_CONFIG=$(echo "$CONFIG" | jq --arg m "$OUTPUT_MODE" '. + {"outputMode": $m}')
-# If language was chosen (not "每次手动选择"):
-NEW_CONFIG=$(echo "$NEW_CONFIG" | jq --arg lang "zh" '. + {"language": $lang}')
 echo "$NEW_CONFIG" > "$CONFIG_PATH"
 CONFIG=$(cat "$CONFIG_PATH")
 ```
-
-Note: `defaultSpeakers` are saved after speaker selection in Step 3 — not here.
 
 ### Quick Mode — `POST /v1/tts`
 
@@ -123,9 +123,12 @@ Get the text to convert. If the user hasn't provided it, ask:
 **Step 2: Determine voice**
 
 - If `config.defaultSpeakers.{language}[0]` is set → use it silently (skip to Step 4)
-- Otherwise: `GET /speakers/list?language={detected-language}`, then follow `shared/speaker-selection.md` (text table + free-text input)
+- If not set → use the **built-in default** from `shared/speaker-selection.md` for the detected language (skip to Step 4)
+- Only show speaker selection if the user explicitly asks to change voice
 
 **Step 3: Save preference**
+
+After the user explicitly selects a new voice (not when using defaults):
 
 ```
 Question: "Save {voice name} as your default voice for {language}?"
@@ -217,7 +220,8 @@ Determine whether the user already has a scripts array:
 For each unique character in the script:
 
 - If `config.defaultSpeakers.{language}` has saved voices → auto-assign silently (one per character in order)
-- Otherwise: fetch `GET /speakers/list?language={detected-language}` and follow `shared/speaker-selection.md` for each character
+- If not set → use **built-in defaults** from `shared/speaker-selection.md` (Primary for first character, Secondary for second)
+- Only show speaker selection if the user explicitly asks to change voices
 
 **Step 3: Save preferences**
 


### PR DESCRIPTION
## Summary

- Simplify onboarding so only `LISTENHUB_API_KEY` is needed to start using any skill
- On first run, config is auto-created with sensible defaults — no setup questions asked
- Add built-in default voices per language (Chinese: 原野 + 高晴, English: Mars + Mia) so speaker selection is automatic
- Setup Flow is now user-initiated only (triggered by explicit "reconfigure" request)
- Existing config is loaded silently without "use saved config?" confirmation prompt

## Changed files

- `shared/config-pattern.md` — Zero-Question Boot pattern: auto-create config, skip Setup Flow
- `shared/speaker-selection.md` — Built-in default speakers table per language
- `shared/output-mode.md` — Clarify setup question is reconfigure-only
- `podcast/SKILL.md` — Apply zero-question boot, default method to "one-step", use built-in speakers
- `tts/SKILL.md` — Apply zero-question boot, use built-in speaker defaults
- `explainer/SKILL.md` — Apply zero-question boot, use built-in speaker defaults
- `content-parser/SKILL.md` — Apply zero-question boot
- `image-gen/SKILL.md` — Apply zero-question boot
- `asr/SKILL.md` — Apply zero-question boot (keeps unique model/polish defaults)

## Test plan

- [ ] First-run: verify each skill creates config silently and proceeds to task immediately
- [ ] Verify Chinese input uses Chinese default voice (原野), English uses English default voice (Mars)
- [ ] Verify 2-speaker mode uses correct male+female pair per language
- [ ] Verify existing config is loaded without confirmation prompt
- [ ] Verify "reconfigure" trigger still works and shows Setup Flow questions
- [ ] Verify ASR still uses sensevoice model and polish=true as defaults

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the initial interaction flow and default voice selection across multiple skills; mistakes could cause unexpected defaults or prevent users from discovering configuration options.
> 
> **Overview**
> Implements **zero-question onboarding** across skills by auto-creating per-skill `.listenhub/*/config.json` with defaults on first run and **loading existing config silently**, removing the previous “where to store config?” and “use saved config?” prompts.
> 
> Moves all **Setup Flow** questions behind an explicit user-initiated reconfigure request, and introduces **built-in default speakers** (zh/en, primary+secondary) so `podcast`, `explainer`, and `tts` can pick voices automatically unless the user asks to change them.
> 
> Adjusts defaults and docs accordingly, including `podcast` defaulting `defaultMethod` to `one-step`, clarifying `outputMode` setup is reconfigure-only, and aligning `asr`, `content-parser`, and `image-gen` to the same boot pattern.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d60815903291628b7dfcd172eb06c9c8ad84fb6. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->