### PR TITLE
feat: add X-Source header for API call source identification

### DIFF
--- a/content-parser/SKILL.md
+++ b/content-parser/SKILL.md
@@ -146,7 +146,8 @@ Wait for explicit confirmation before calling the API.
    TASK_ID="<id-from-step-3>"
    for i in $(seq 1 60); do
      RESULT=$(curl -sS "https://api.marswave.ai/openapi/v1/content/extract/$TASK_ID" \
-       -H "Authorization: Bearer $LISTENHUB_API_KEY" 2>/dev/null)
+       -H "Authorization: Bearer $LISTENHUB_API_KEY" \
+       -H "X-Source: skills" 2>/dev/null)
      STATUS=$(echo "$RESULT" | tr -d '\000-\037\177' | jq -r '.data.status // "processing"')
      case "$STATUS" in
        completed) echo "$RESULT"; exit 0 ;;
@@ -207,6 +208,7 @@ Wait for explicit confirmation before calling the API.
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/content/extract" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   -d '{
     "source": {
       "type": "url",
@@ -219,7 +221,8 @@ curl -sS -X POST "https://api.marswave.ai/openapi/v1/content/extract" \
 
 ```bash
 curl -sS "https://api.marswave.ai/openapi/v1/content/extract/69a7dac700cf95938f86d9bb" \
-  -H "Authorization: Bearer $LISTENHUB_API_KEY"
+  -H "Authorization: Bearer $LISTENHUB_API_KEY" \
+  -H "X-Source: skills"
 ```
 
 5. Present extracted content preview and offer next actions.
@@ -237,6 +240,7 @@ curl -sS "https://api.marswave.ai/openapi/v1/content/extract/69a7dac700cf95938f8
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/content/extract" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   -d '{
     "source": {
       "type": "url",

--- a/explainer/SKILL.md
+++ b/explainer/SKILL.md
@@ -179,7 +179,8 @@ Wait for explicit confirmation before calling any API.
    EPISODE_ID="<id-from-step-1>"
    for i in $(seq 1 30); do
      RESULT=$(curl -sS "https://api.marswave.ai/openapi/v1/storybook/episodes/$EPISODE_ID" \
-       -H "Authorization: Bearer $LISTENHUB_API_KEY" 2>/dev/null)
+       -H "Authorization: Bearer $LISTENHUB_API_KEY" \
+       -H "X-Source: skills" 2>/dev/null)
      STATUS=$(echo "$RESULT" | tr -d '\000-\037\177' | jq -r '.data.processStatus // "pending"')
      case "$STATUS" in
        success|completed) echo "$RESULT"; exit 0 ;;
@@ -216,7 +217,8 @@ Wait for explicit confirmation before calling any API.
    EPISODE_ID="<id-from-step-1>"
    for i in $(seq 1 30); do
      RESULT=$(curl -sS "https://api.marswave.ai/openapi/v1/storybook/episodes/$EPISODE_ID" \
-       -H "Authorization: Bearer $LISTENHUB_API_KEY" 2>/dev/null)
+       -H "Authorization: Bearer $LISTENHUB_API_KEY" \
+       -H "X-Source: skills" 2>/dev/null)
      STATUS=$(echo "$RESULT" | tr -d '\000-\037\177' | jq -r '.data.videoStatus // "pending"')
      case "$STATUS" in
        success|completed) echo "$RESULT"; exit 0 ;;
@@ -298,6 +300,7 @@ echo "$NEW_CONFIG" > "$CONFIG_PATH"
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/storybook/episodes" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   -d '{
     "sources": [{"type": "text", "content": "Introduce Claude Code: what it is, key features, and how to get started"}],
     "speakers": [{"speakerId": "cozy-man-english"}],

--- a/image-gen/SKILL.md
+++ b/image-gen/SKILL.md
@@ -254,6 +254,7 @@ echo "$BASE64_DATA" | base64 --decode > output.jpg
 RESPONSE=$(curl -sS -X POST "https://api.labnana.com/openapi/v1/images/generation" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   --max-time 600 \
   -d '{
     "provider": "google",

--- a/podcast/SKILL.md
+++ b/podcast/SKILL.md
@@ -214,7 +214,8 @@ Wait for explicit confirmation before calling any API.
    EPISODE_ID="<id-from-step-1>"
    for i in $(seq 1 30); do
      RESULT=$(curl -sS "https://api.marswave.ai/openapi/v1/podcast/episodes/$EPISODE_ID" \
-       -H "Authorization: Bearer $LISTENHUB_API_KEY" 2>/dev/null)
+       -H "Authorization: Bearer $LISTENHUB_API_KEY" \
+       -H "X-Source: skills" 2>/dev/null)
      STATUS=$(echo "$RESULT" | tr -d '\000-\037\177' | jq -r '.data.processStatus // "pending"')
      case "$STATUS" in
        success|completed) echo "$RESULT"; exit 0 ;;
@@ -312,6 +313,7 @@ echo "$NEW_CONFIG" > "$CONFIG_PATH"
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/podcast/episodes" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   -d '{
     "sources": [{"type": "text", "content": "The latest AI developments"}],
     "speakers": [{"speakerId": "cozy-man-english"}],

--- a/shared/api-content-extract.md
+++ b/shared/api-content-extract.md
@@ -25,6 +25,7 @@ Create a content extraction task for a URL. Returns a `taskId` for polling.
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/content/extract" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   -d '{
     "source": {
       "type": "url",
@@ -39,6 +40,7 @@ curl -sS -X POST "https://api.marswave.ai/openapi/v1/content/extract" \
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/content/extract" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   -d '{
     "source": {
       "type": "url",
@@ -87,7 +89,8 @@ Get extraction task status and results.
 
 ```bash
 curl -sS "https://api.marswave.ai/openapi/v1/content/extract/69a7dac700cf95938f86d9bb" \
-  -H "Authorization: Bearer $LISTENHUB_API_KEY"
+  -H "Authorization: Bearer $LISTENHUB_API_KEY" \
+  -H "X-Source: skills"
 ```
 
 **Response (processing):**

--- a/shared/api-image.md
+++ b/shared/api-image.md
@@ -61,6 +61,7 @@ Infer `mimeType` from URL suffix: `.jpg`/`.jpeg` → `image/jpeg`, `.png` → `i
 RESPONSE=$(curl -sS -X POST "https://api.labnana.com/openapi/v1/images/generation" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   --max-time 600 \
   -d '{
     "provider": "google",

--- a/shared/api-podcast.md
+++ b/shared/api-podcast.md
@@ -37,6 +37,7 @@ Create a podcast episode.
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/podcast/episodes" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   -d '{
     "query": "The future of AI development",
     "sources": [{"type": "text", "content": "Reference material about AI trends"}],
@@ -72,7 +73,8 @@ Get podcast episode details and status.
 
 ```bash
 curl -sS "https://api.marswave.ai/openapi/v1/podcast/episodes/688c9a27348f001e707ba331" \
-  -H "Authorization: Bearer $LISTENHUB_API_KEY"
+  -H "Authorization: Bearer $LISTENHUB_API_KEY" \
+  -H "X-Source: skills"
 ```
 
 **Response:**

--- a/shared/api-speakers.md
+++ b/shared/api-speakers.md
@@ -18,7 +18,8 @@ Get available voice speakers, optionally filtered by language.
 
 ```bash
 curl -sS "https://api.marswave.ai/openapi/v1/speakers/list?language=en" \
-  -H "Authorization: Bearer $LISTENHUB_API_KEY"
+  -H "Authorization: Bearer $LISTENHUB_API_KEY" \
+  -H "X-Source: skills"
 ```
 
 **Response:**

--- a/shared/api-storybook.md
+++ b/shared/api-storybook.md
@@ -35,6 +35,7 @@ Create a storybook episode. Returns an `episodeId` immediately; generation runs 
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/storybook/episodes" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   -d '{
     "sources": [{"type": "text", "content": "The history of the Roman Empire"}],
     "speakers": [{"speakerId": "cozy-man-english"}],
@@ -71,7 +72,8 @@ Get storybook episode status and result.
 
 ```bash
 curl -sS "https://api.marswave.ai/openapi/v1/storybook/episodes/688c9a27348f001e707ba331" \
-  -H "Authorization: Bearer $LISTENHUB_API_KEY"
+  -H "Authorization: Bearer $LISTENHUB_API_KEY" \
+  -H "X-Source: skills"
 ```
 
 **Response:**
@@ -142,7 +144,8 @@ Trigger video generation for a completed storybook episode. Video combines the p
 
 ```bash
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/storybook/episodes/688c9a27348f001e707ba331/video" \
-  -H "Authorization: Bearer $LISTENHUB_API_KEY"
+  -H "Authorization: Bearer $LISTENHUB_API_KEY" \
+  -H "X-Source: skills"
 ```
 
 **Response:**

--- a/shared/api-tts.md
+++ b/shared/api-tts.md
@@ -23,6 +23,7 @@ Low-latency single-voice TTS. Returns a **streaming binary MP3** — not JSON.
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/tts" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   -d '{
     "input": "Hello, welcome to ListenHub.",
     "voice": "EN-Man-General-01"
@@ -57,6 +58,7 @@ Multi-speaker script-to-audio. Each script segment uses a different voice. Retur
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/speech" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   -d '{
     "scripts": [
       {"content": "Welcome everyone.", "speakerId": "EN-Man-General-01"},

--- a/shared/authentication.md
+++ b/shared/authentication.md
@@ -35,7 +35,10 @@ Every request must include:
 ```
 Authorization: Bearer $LISTENHUB_API_KEY
 Content-Type: application/json
+X-Source: skills
 ```
+
+The `X-Source: skills` header identifies requests as coming from Claude Code skills (CLI tool), distinguishing them from `openapi` (web) or other sources on the server side.
 
 ## curl Template
 
@@ -43,6 +46,7 @@ Content-Type: application/json
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/{endpoint}" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   -d '{ ... }'
 ```
 

--- a/shared/common-patterns.md
+++ b/shared/common-patterns.md
@@ -25,6 +25,7 @@ All polling MUST run in the background using Bash `run_in_background: true`. Thi
 RESPONSE=$(curl -sS -X POST "https://api.marswave.ai/openapi/v1/podcast/episodes" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   -d '{ ... }')
 
 EPISODE_ID=$(echo "$RESPONSE" | jq -r '.data.episodeId')
@@ -42,7 +43,8 @@ Run this as a **separate Bash call** with `run_in_background: true`:
 EPISODE_ID="<id-from-step-1>"
 for i in $(seq 1 30); do
   RESULT=$(curl -sS "https://api.marswave.ai/openapi/v1/podcast/episodes/$EPISODE_ID" \
-    -H "Authorization: Bearer $LISTENHUB_API_KEY" 2>/dev/null)
+    -H "Authorization: Bearer $LISTENHUB_API_KEY" \
+    -H "X-Source: skills" 2>/dev/null)
 
   STATUS=$(echo "$RESULT" | tr -d '\000-\037\177' | jq -r '.data.processStatus // "pending"')
 
@@ -137,6 +139,7 @@ ENDJSON
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/podcast/episodes" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   -d @/tmp/lh-request.json
 ```
 

--- a/tts/SKILL.md
+++ b/tts/SKILL.md
@@ -151,6 +151,7 @@ Proceed?
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/tts" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   -d '{"input": "...", "voice": "..."}' \
   --output /tmp/tts-output.mp3
 ```
@@ -167,6 +168,7 @@ JOB_ID=$(date +%s)
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/tts" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   -d '{"input": "...", "voice": "..."}' \
   --output /tmp/tts-${JOB_ID}.mp3
 ```
@@ -186,6 +188,7 @@ mkdir -p "$JOB_DIR"
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/tts" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   -d '{"input": "...", "voice": "..."}' \
   --output "${JOB_DIR}/${JOB_ID}.mp3"
 ```
@@ -263,6 +266,7 @@ ENDJSON
 curl -sS -X POST "https://api.marswave.ai/openapi/v1/speech" \
   -H "Authorization: Bearer $LISTENHUB_API_KEY" \
   -H "Content-Type: application/json" \
+  -H "X-Source: skills" \
   -d @/tmp/lh-speech-request.json
 
 rm /tmp/lh-speech-request.json


### PR DESCRIPTION
## Summary

- Add `X-Source: skills` custom HTTP header to all API curl command templates across shared docs and skill files
- Update `shared/authentication.md` to document `X-Source` as a required header with explanation of its purpose
- Covers all 13 files: 7 shared API/pattern docs + 6 skill SKILL.md files (podcast, tts, explainer, content-parser, image-gen, speakers)

This enables the server to distinguish requests from Claude Code skills (CLI tool) vs openapi (web) or other sources, resolving the issue where all API calls appeared as `openapi` origin.

## Test plan

- [ ] Verify all curl examples in shared docs include `X-Source: skills` header
- [ ] Verify all curl examples in SKILL.md files include `X-Source: skills` header
- [ ] Test a skill (e.g. `/podcast`) end-to-end and confirm the header is present in outgoing requests
- [ ] Confirm server-side can read and log the `X-Source` header value

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; it standardizes request headers in examples but does not alter runtime code or API behavior.
> 
> **Overview**
> **Adds a new required request header across docs.** All curl examples in skill `SKILL.md` files and shared API reference/pattern docs now include `-H "X-Source: skills"` so server-side logging can distinguish Claude Code skill traffic from other clients.
> 
> **Documents the requirement.** `shared/authentication.md` is updated to list `X-Source: skills` as a required header and briefly explains its purpose.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8622b77c194be3587d51b94d412795ae06937581. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->