### PR TITLE
fix: address review findings on creator workflow design

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,3 @@ Thumbs.db
 *.temp
 
 .worktrees/
-.obsidian/

--- a/creator/SKILL.md
+++ b/creator/SKILL.md
@@ -61,7 +61,7 @@ Follow `shared/config-pattern.md` Step 0 (Zero-Question Boot).
 ```bash
 mkdir -p ".listenhub/creator"
 cat > ".listenhub/creator/config.json" << 'EOF'
-{"outputMode":"download","language":null,"preferences":{"wechat":{"styleNotes":[],"history":[]},"xiaohongshu":{"styleNotes":[],"mode":"both","history":[]},"narration":{"styleNotes":[],"history":[]}}}
+{"outputMode":"download","language":null,"preferences":{"wechat":{"styleNotes":[],"history":[]},"xiaohongshu":{"styleNotes":[],"mode":"both","history":[]},"narration":{"styleNotes":[],"defaultSpeaker":null,"history":[]}}}
 EOF
 CONFIG_PATH=".listenhub/creator/config.json"
 CONFIG=$(cat "$CONFIG_PATH")
@@ -135,7 +135,9 @@ Options (adapt language to user's input):
 
 ### Step 3: Style Learning Check (silent)
 
-Before the confirmation gate, check if there's a previous generation to learn from:
+Before the confirmation gate, check if there's a previous generation to learn from.
+
+**Note**: Style learning uses relative paths from `history[].output`. It only works when running creator from the same working directory as the previous generation. If the output folder is not found, this step is silently skipped.
 
 ```bash
 PLATFORM="{selected platform}"
@@ -214,7 +216,7 @@ RESPONSE=$(curl -sS -X POST "https://api.marswave.ai/openapi/v1/content/extract"
 TASK_ID=$(echo "$RESPONSE" | jq -r '.data.taskId')
 ```
 
-Then poll in background. Run this as a **separate Bash call** with `run_in_background: true` and `timeout: 600000` (per `shared/common-patterns.md`). Content-parser uses 5s intervals; 60 polls × 5s = 300s matches the standard 300s timeout budget:
+Then poll in background. Run this as a **separate Bash call** with `run_in_background: true` and `timeout: 600000` (per `shared/common-patterns.md`). The polling loop itself runs up to 300s (60 polls × 5s); `timeout: 600000` is set higher at the tool level to give the Bash process headroom beyond the poll budget:
 
 ```bash
 # Run with: run_in_background: true, timeout: 600000
@@ -263,7 +265,7 @@ else
 fi
 ```
 
-On 429: wait 15s, retry up to 3 times. On failure after retries: skip this image, annotate in output summary.
+On 429: exponential backoff (wait 15s → 30s → 60s), retry up to 3 times. On failure after retries: skip this image, annotate in output summary.
 
 Generate images **sequentially** (not parallel) to respect rate limits.
 
@@ -347,7 +349,7 @@ NEW_CONFIG=$(echo "$CONFIG" | jq \
 echo "$NEW_CONFIG" > "$CONFIG_PATH"
 ```
 
-Keep only the last 5 history entries per platform. Note: `output` stores the folder path (e.g., `ai-future-wechat/`), not a file path. The style learning check in Step 3 uses this to find `.original/` snapshots.
+Keep only the last 5 history entries per platform. Note: `output` stores the folder path (e.g., `ai-future-wechat/`), relative to the CWD where creator was invoked. The style learning check in Step 3 uses this to find `.original/` snapshots.
 
 Note: `cardStyle` from the spec is deferred — not implemented in V1 config. Can be added later when card style customization is needed.
 

--- a/creator/templates/narration/template.md
+++ b/creator/templates/narration/template.md
@@ -25,9 +25,12 @@ TTS is offered only if:
 
 If generating audio:
 
-1. Select speaker using built-in defaults from `shared/speaker-selection.md`:
-   - Chinese: "原野" (`CN-Man-Beijing-V2`)
-   - English: "Mars" (`cozy-man-english`)
+1. Select speaker:
+   - Check `preferences.narration.defaultSpeaker` in config — if set, use it
+   - Otherwise use built-in defaults from `shared/speaker-selection.md`:
+     - Chinese: "原野" (`CN-Man-Beijing-V2`)
+     - English: "Mars" (`cozy-man-english`)
+   - On first TTS use, ask the user via AskUserQuestion if they want to choose a different speaker. Save their choice to `preferences.narration.defaultSpeaker` for future runs.
 
 2. Call TTS API (use `@file` pattern for safe text handling per `shared/common-patterns.md`):
 ```bash

--- a/creator/templates/xiaohongshu/style.md
+++ b/creator/templates/xiaohongshu/style.md
@@ -26,6 +26,7 @@
 ## Image Prompt Guidelines for Cards
 - Describe the card as a graphic design composition, not a photo
 - Include: text content, layout direction, color palette, typography style
+- **Keep on-card text short** (under 10 Chinese characters per line) — AI image models render long text or complex characters unreliably. Users should expect to manually adjust text on generated cards.
 - Example prompt: "Minimalist card design with bold Chinese text '5个关键习惯' centered, subtitle '改变你的生活' below, clean white background with soft blue gradient accent, modern sans-serif typography"
 
 ## Language

--- a/docs/superpowers/specs/2026-03-23-creator-workflow-design.md
+++ b/docs/superpowers/specs/2026-03-23-creator-workflow-design.md
@@ -61,7 +61,7 @@ creator/
     │   ├── template.md         # Script generation workflow
     │   └── style.md            # Spoken-word style guide
     │
-    └── ppt/                    # Future placeholder
+    └── ppt/                    # Future placeholder (not created in V1)
         ├── template.md
         └── style.md
 ```
@@ -143,6 +143,7 @@ After execution, record output path in history. On next run, compare previous ou
 2. Distill content into 5-8 key points/pages
 3. Design each page: core quote + brief explanation + visual theme description
 4. Call image-gen to generate integrated text-on-image cards for each page
+   - **Note**: AI image generation models may render Chinese text imperfectly. Generated cards may need manual text adjustment. Prompts should keep on-card text short (under 10 characters per line) for best results.
 5. Generate cover card (attention-grabbing title)
 
 **Long text mode**:
@@ -250,7 +251,7 @@ On first run, silently create `.listenhub/creator/config.json` with defaults:
   "preferences": {
     "wechat": { "styleNotes": [], "history": [] },
     "xiaohongshu": { "styleNotes": [], "mode": "both", "history": [] },
-    "narration": { "styleNotes": [], "history": [] }
+    "narration": { "styleNotes": [], "defaultSpeaker": null, "history": [] }
   }
 }
 ```
@@ -272,7 +273,7 @@ Follows `shared/config-pattern.md` conventions.
       "history": [
         {
           "date": "2026-03-22",
-          "output": "ai-future-wechat/article.md",
+          "output": "ai-future-wechat/",
           "topic": "AI的未来"
         }
       ]
@@ -285,6 +286,7 @@ Follows `shared/config-pattern.md` conventions.
     },
     "narration": {
       "styleNotes": [],
+      "defaultSpeaker": null,
       "history": []
     }
   }
@@ -293,13 +295,15 @@ Follows `shared/config-pattern.md` conventions.
 
 - `mode` (xiaohongshu only): `"both"` | `"cards"` | `"long-text"` — which sub-mode to generate
 - `styleNotes`: Max 10 entries per platform, newest replaces oldest
+- `defaultSpeaker` (narration only): Speaker ID for TTS (e.g., `CN-Man-Beijing-V2`), `null` uses built-in defaults
 - `history`: Last 5 generation records for automatic learning
 
 ### Evolution Mechanisms
 
 **Automatic learning**:
 - Each generation saves a snapshot of the main output file alongside the output. For example, `{slug}-wechat/.original/article.md` is an exact copy of the generated `article.md` before any user edits.
-- Each generation records output path in `config.json` → `preferences.{platform}.history`
+- Each generation records output folder path in `config.json` → `preferences.{platform}.history` (relative to the CWD where creator was invoked)
+- **CWD dependency**: Style learning only works when the user runs creator from the same working directory as the previous generation. If the previous output folder is not found at the recorded relative path, style learning is silently skipped.
 - On next run, if `.original/article.md` exists and differs from the current `article.md`, compute the diff
 - Present the diff to the AI with the prompt: "The user edited the generated content. What style preferences can you infer? Express each as a short directive (e.g., '减少 emoji 使用', '段落更短')."
 - Append inferred notes to `styleNotes`; array keeps latest 10 entries, newer replaces older
@@ -354,7 +358,7 @@ Creator:
 ### Error Handling
 
 - content-parser fails → "URL 解析失败，你可以直接粘贴文字内容给我"
-- image-gen fails → Retry once; if still fails, deliver article without that image, annotate which images were not generated
+- image-gen 429 → Exponential backoff (15s → 30s → 60s), retry up to 3 times; if still fails, deliver article without that image, annotate which images were not generated
 - API key missing at confirmation gate → Run interactive setup, do not proceed without it
 - `coli` unavailable → Skip transcription step, ask user to paste text instead or install coli
 - tts fails → Deliver script without audio, note that TTS generation failed


### PR DESCRIPTION
## Summary

Fixes review findings from PR #14:

- **Config history path consistency**: `output` field now stores folder path (`ai-future-wechat/`), not file path
- **Style learning CWD caveat**: Document that style learning only works from same working directory
- **Image-gen retry backoff**: Exponential backoff (15s → 30s → 60s) instead of fixed 15s intervals
- **XHS card text rendering**: Added caveat about AI model Chinese text rendering limitations
- **TTS speaker config**: Added `defaultSpeaker` to narration preferences (configurable, not hardcoded)
- **Polling timeout clarification**: Distinguished poll budget (300s) from tool-level timeout (600s)
- **`.obsidian/` in gitignore**: Removed from project gitignore (belongs in global)
- **PPT placeholder**: Marked as "not created in V1" in spec directory tree

## Test plan

- [ ] Review each fix against the original review comment
- [ ] Verify config schema consistency between spec and SKILL.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that adjust the creator workflow spec/config schema and retry guidance; low risk but could affect how implementers interpret paths and TTS speaker defaults.
> 
> **Overview**
> Tightens the `creator` workflow docs/spec to address review feedback: config defaults now include `preferences.narration.defaultSpeaker`, narration TTS selection is described as configurable/persisted, and history `output` is clarified to store an output *folder* path (relative to the working directory) with an explicit CWD dependency for style learning.
> 
> Clarifies operational guidance: separates polling budget from tool timeout, switches image-gen 429 handling to exponential backoff, and adds Xiaohongshu card prompt guidance about keeping on-card Chinese text short due to model limitations. Also removes `.obsidian/` from `.gitignore` and marks the `ppt/` template as not created in V1.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f3c860e7b535db2fa1dd0c7a5699d0e2195fe3b. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->