### PR TITLE
fix(creator): ask user to choose preset instead of auto-selecting

### DIFF
--- a/creator/SKILL.md
+++ b/creator/SKILL.md
@@ -206,6 +206,7 @@ If API key required and missing: run `shared/authentication.md` interactive setu
   输出目录：{slug}-{platform}/
   需要 API 调用：{content-parser, image-gen, ...}
   风格偏好：{styles/{platform}.md 已配置 / 使用默认风格}
+  配图/卡片预设：{preset label / 待选择}
   本次风格参考：{M条来自参考文章 / 无}
 
 确认开始？

--- a/creator/SKILL.md
+++ b/creator/SKILL.md
@@ -185,6 +185,16 @@ If yes → write to `.listenhub/creator/styles/{platform}.md`. If no → only ap
 
 **Standalone style learning:** If the user only provided a style reference without material/topic (e.g., "学习一下这篇文章的风格"), run the extraction above, then **persist directly** to `.listenhub/creator/styles/{platform}.md` without asking — the user's intent to save is already explicit. Confirm with a brief message: "已保存到 styles/{platform}.md". Do not proceed to content generation.
 
+### Step 3b: Preset Selection (if applicable)
+
+If the selected template uses illustration or card presets (wechat, xiaohongshu), the preset MUST be chosen **before** the confirmation gate so it can be displayed in the summary.
+
+1. Read the template's preset section to get available presets and the topic-matching table.
+2. **If the user already specified a preset** in their prompt (e.g., "用水彩风格"): use that preset directly.
+3. **If not specified**: ask the user via AskUserQuestion. Output a one-line hint first: "配图风格可以随时换，先选一个开始吧". List all available presets with their Chinese labels (from frontmatter `label` field). Use the topic-matching table to put the most relevant option first (marked "Recommended"), but always let the user choose.
+
+Templates that do not use presets (e.g., narration): skip this step.
+
 ### Step 4: Confirmation Gate
 
 **Check API key** if the pipeline needs remote APIs:

--- a/creator/SKILL.md
+++ b/creator/SKILL.md
@@ -144,7 +144,7 @@ Options (adapt language to user's input):
 
 ### Step 3: Style Extraction (if style reference provided)
 
-This step runs only when the user provided a style reference in Step 1. If no style reference was detected, skip to Step 4.
+This step runs only when the user provided a style reference in Step 1. If no style reference was detected, skip to Step 3b.
 
 **Read the reference content:**
 - Local file → Read tool
@@ -187,13 +187,17 @@ If yes → write to `.listenhub/creator/styles/{platform}.md`. If no → only ap
 
 ### Step 3b: Preset Selection (if applicable)
 
-If the selected template uses illustration or card presets (wechat, xiaohongshu), the preset MUST be chosen **before** the confirmation gate so it can be displayed in the summary.
+If the selected template uses illustration or card presets **and** the mode requires images, the preset MUST be chosen **before** the confirmation gate so it can be displayed in the summary.
+
+**Skip this step entirely** for:
+- Narration template (no visual presets)
+- Xiaohongshu with `preferences.xiaohongshu.mode` = `"long-text"` (no cards or images generated)
+
+Otherwise:
 
 1. Read the template's preset section to get available presets and the topic-matching table.
 2. **If the user already specified a preset** in their prompt (e.g., "用水彩风格"): use that preset directly.
 3. **If not specified**: ask the user via AskUserQuestion. Output a one-line hint first: "配图风格可以随时换，先选一个开始吧". List all available presets with their Chinese labels (from frontmatter `label` field). Use the topic-matching table to put the most relevant option first (marked "Recommended"), but always let the user choose.
-
-Templates that do not use presets (e.g., narration): skip this step.
 
 ### Step 4: Confirmation Gate
 
@@ -216,7 +220,7 @@ If API key required and missing: run `shared/authentication.md` interactive setu
   输出目录：{slug}-{platform}/
   需要 API 调用：{content-parser, image-gen, ...}
   风格偏好：{styles/{platform}.md 已配置 / 使用默认风格}
-  配图/卡片预设：{preset label / 待选择}
+  配图/卡片预设：{preset label / 不适用}
   本次风格参考：{M条来自参考文章 / 无}
 
 确认开始？

--- a/creator/templates/wechat/template.md
+++ b/creator/templates/wechat/template.md
@@ -36,7 +36,7 @@ Choose an illustration preset from `presets/` for image generation.
 | 文化, 读书, 情感, 文艺, 哲学 | watercolor |
 | 商业, 产品, 前沿科技, 城市 | photo-realistic |
 
-The selected preset MUST be shown in the Step 4 confirmation summary.
+The selected preset MUST be shown in the confirmation gate summary (SKILL.md Step 4).
 
 After selection, read the full preset file to get the Prompt Fragment for use in Step 5.
 

--- a/creator/templates/wechat/template.md
+++ b/creator/templates/wechat/template.md
@@ -26,9 +26,9 @@ Write the complete article as `article.md` in the output folder.
 
 Choose an illustration preset from `presets/` for image generation.
 
-**If user specified a preset** (e.g., "用水彩风格"): use that preset directly.
+**If user specified a preset** (e.g., "用水彩风格"): use that preset directly, skip the question below.
 
-**If not specified**: auto-select based on content topic:
+**If not specified**: MUST ask the user via AskUserQuestion. Before presenting the options, output a one-line hint: "配图风格可以随时换，先选一个开始吧". List all available presets with their Chinese labels (from frontmatter `label` field). Use the topic-matching table below only as a hint to put the most relevant option first (marked "Recommended"), but always let the user choose:
 
 | Content Signals | Recommended Preset |
 |---|---|
@@ -36,7 +36,7 @@ Choose an illustration preset from `presets/` for image generation.
 | 文化, 读书, 情感, 文艺, 哲学 | watercolor |
 | 商业, 产品, 前沿科技, 城市 | photo-realistic |
 
-Show the selected preset in the confirmation gate. User can override.
+The selected preset MUST be shown in the Step 4 confirmation summary.
 
 After selection, read the full preset file to get the Prompt Fragment for use in Step 5.
 

--- a/creator/templates/wechat/template.md
+++ b/creator/templates/wechat/template.md
@@ -24,11 +24,9 @@ Write the complete article as `article.md` in the output folder.
 
 ### 4. Select Illustration Preset
 
-Choose an illustration preset from `presets/` for image generation.
+The preset was already selected in SKILL.md Step 3b (before the confirmation gate). Use the preset chosen there.
 
-**If user specified a preset** (e.g., "用水彩风格"): use that preset directly, skip the question below.
-
-**If not specified**: MUST ask the user via AskUserQuestion. Before presenting the options, output a one-line hint: "配图风格可以随时换，先选一个开始吧". List all available presets with their Chinese labels (from frontmatter `label` field). Use the topic-matching table below only as a hint to put the most relevant option first (marked "Recommended"), but always let the user choose:
+Available presets and topic-matching hints (used by SKILL.md Step 3b for ordering recommendations):
 
 | Content Signals | Recommended Preset |
 |---|---|
@@ -36,9 +34,7 @@ Choose an illustration preset from `presets/` for image generation.
 | 文化, 读书, 情感, 文艺, 哲学 | watercolor |
 | 商业, 产品, 前沿科技, 城市 | photo-realistic |
 
-The selected preset MUST be shown in the confirmation gate summary (SKILL.md Step 4).
-
-After selection, read the full preset file to get the Prompt Fragment for use in Step 5.
+Read the full preset file to get the Prompt Fragment for use in Step 5.
 
 ### 5. Plan Illustrations
 

--- a/creator/templates/xiaohongshu/template.md
+++ b/creator/templates/xiaohongshu/template.md
@@ -15,11 +15,9 @@ Read `preferences.xiaohongshu.mode` from config:
 
 ### 3. Select Visual Preset (if mode includes cards)
 
-Choose a visual preset from `presets/` for card generation.
+The preset was already selected in SKILL.md Step 3b (before the confirmation gate). Use the preset chosen there.
 
-**If user specified a preset** (e.g., "用 notion 风格"): use that preset directly, skip the question below.
-
-**If not specified**: MUST ask the user via AskUserQuestion. Before presenting the options, output a one-line hint: "配图风格可以随时换，先选一个开始吧". List all available presets with their Chinese labels (from frontmatter `label` field). Use the topic-matching table below only as a hint to put the most relevant option first (marked "Recommended"), but always let the user choose:
+Available presets and topic-matching hints (used by SKILL.md Step 3b for ordering recommendations):
 
 | Content Signals | Recommended Preset |
 |---|---|
@@ -34,9 +32,7 @@ Choose a visual preset from `presets/` for card generation.
 | 教程, 学习方法, 教学 | chalkboard |
 | 笔记, 考试, 学习, 框架 | study-notes |
 
-The selected preset MUST be shown in the confirmation gate summary (SKILL.md Step 4).
-
-After selection, read the full preset file to get Color Palette, Typography, Decorations, and Prompt Fragment for use in Step 5.
+Read the full preset file to get Color Palette, Typography, Decorations, and Prompt Fragment for use in Step 5.
 
 ### 4. Generate Content Plan
 

--- a/creator/templates/xiaohongshu/template.md
+++ b/creator/templates/xiaohongshu/template.md
@@ -34,7 +34,7 @@ Choose a visual preset from `presets/` for card generation.
 | 教程, 学习方法, 教学 | chalkboard |
 | 笔记, 考试, 学习, 框架 | study-notes |
 
-The selected preset MUST be shown in the Step 4 confirmation summary.
+The selected preset MUST be shown in the confirmation gate summary (SKILL.md Step 4).
 
 After selection, read the full preset file to get Color Palette, Typography, Decorations, and Prompt Fragment for use in Step 5.
 

--- a/creator/templates/xiaohongshu/template.md
+++ b/creator/templates/xiaohongshu/template.md
@@ -17,9 +17,9 @@ Read `preferences.xiaohongshu.mode` from config:
 
 Choose a visual preset from `presets/` for card generation.
 
-**If user specified a preset** (e.g., "用 notion 风格"): use that preset directly.
+**If user specified a preset** (e.g., "用 notion 风格"): use that preset directly, skip the question below.
 
-**If not specified**: auto-select by scanning frontmatter of all `presets/*.md` files. Match the content topic against `best_for` and `mood` fields:
+**If not specified**: MUST ask the user via AskUserQuestion. Before presenting the options, output a one-line hint: "配图风格可以随时换，先选一个开始吧". List all available presets with their Chinese labels (from frontmatter `label` field). Use the topic-matching table below only as a hint to put the most relevant option first (marked "Recommended"), but always let the user choose:
 
 | Content Signals | Recommended Preset |
 |---|---|
@@ -34,7 +34,7 @@ Choose a visual preset from `presets/` for card generation.
 | 教程, 学习方法, 教学 | chalkboard |
 | 笔记, 考试, 学习, 框架 | study-notes |
 
-Show the selected preset in the confirmation gate. User can override.
+The selected preset MUST be shown in the Step 4 confirmation summary.
 
 After selection, read the full preset file to get Color Palette, Typography, Decorations, and Prompt Fragment for use in Step 5.
 


### PR DESCRIPTION
## Summary
- Wechat and Xiaohongshu templates now MUST ask the user to choose an illustration/card preset via AskUserQuestion, instead of silently auto-selecting
- Added a lightweight hint before the options: "配图风格可以随时换，先选一个开始吧"
- Selected preset is required in the Step 4 confirmation summary so users can review before generation

## Why
Auto-select often picks the wrong style for vague topics (e.g. "test" defaulted to notion). The confirmation summary also omitted the preset field entirely, so users had no chance to override.

## Test plan
- [ ] Run `/creator` with a vague topic — should be asked to pick a preset
- [ ] Run `/creator` with explicit preset (e.g. "用水彩风格") — should skip the question
- [ ] Verify confirmation summary includes the preset name

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the creator workflow interaction flow by inserting a new preset-selection step and surfacing the chosen preset in the confirmation summary, which could alter/break existing generation flows if any callers assumed auto-selection or different step ordering.
> 
> **Overview**
> Updates the `creator` workflow to **select illustration/card presets explicitly via `AskUserQuestion` before the confirmation gate**, so users can review/override the choice before generation.
> 
> Adds a new `Step 3b` for preset selection (skipped for narration and Xiaohongshu `long-text` mode), includes a one-line hint prompt, and extends the confirmation summary to display `配图/卡片预设`.
> 
> Aligns WeChat and Xiaohongshu templates to treat preset choice as preselected by the dispatcher, leaving only the preset tables as recommendation/ordering hints rather than auto-selection logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29ff230e38fa1eb44b3dd216410801ca01b49741. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->