### PR TITLE
docs(skills): update Gemini image model IDs

### DIFF
--- a/cola-avatar-pack/GENERATE.md
+++ b/cola-avatar-pack/GENERATE.md
@@ -367,7 +367,7 @@ Phase 4 写入 `avatar.json` 后，`base_prompt` 和 `negative_prompt` 即为冻
 
 ```
 action: generate_image
-model: gemini-3-pro-image-preview
+model: gemini-3-pro-image
 size: 1K
 ratio: 1:1
 ```

--- a/creator/templates/wechat/template.md
+++ b/creator/templates/wechat/template.md
@@ -71,7 +71,7 @@ After writing, identify illustration positions:
 
 For each planned illustration, call the image generation API:
 
-- **Model**: `gemini-3-pro-image-preview`
+- **Model**: `gemini-3-pro-image`
 - **Cover**: aspect ratio `3:2`, size `2K`
 - **Body images**: aspect ratio `3:2` or `16:9`, size `2K`
 - **Timeout**: `--timeout 600` (use `listenhub image create --json`)

--- a/creator/templates/xiaohongshu/template.md
+++ b/creator/templates/xiaohongshu/template.md
@@ -138,7 +138,7 @@ Save all prompts to `{output}/cards/prompts.json`:
 ### 7. Generate Card Images (if mode includes cards)
 
 For each prompt in `prompts.json`:
-- **Model**: `gemini-3-pro-image-preview`
+- **Model**: `gemini-3-pro-image`
 - **Aspect ratio**: `3:4` (portrait, standard Xiaohongshu card)
 - **Size**: `2K`
 - **Timeout**: `--timeout 600` (use `listenhub image create --json`)

--- a/image-gen/SKILL.md
+++ b/image-gen/SKILL.md
@@ -113,8 +113,8 @@ Ask:
 ```
 Question: "Which model?"
 Options:
-  - "pro (recommended)" — gemini-3-pro-image-preview, higher quality
-  - "flash" — gemini-3.1-flash-image-preview, faster and cheaper, unlocks extreme aspect ratios (1:4, 4:1, 1:8, 8:1)
+  - "pro (recommended)" — gemini-3-pro-image, higher quality
+  - "flash" — gemini-3.1-flash-image, faster and cheaper, unlocks extreme aspect ratios (1:4, 4:1, 1:8, 8:1)
 ```
 
 ### Step 3: Resolution and Aspect Ratio
@@ -291,7 +291,7 @@ Wait for explicit confirmation before running the CLI command.
 ```bash
 $CMD_PREFIX create \
   --prompt "cyberpunk city at night" \
-  --model "gemini-3-pro-image-preview" \
+  --model "gemini-3-pro-image" \
   --lang en \
   --aspect-ratio 16:9 \
   --size 2K \
@@ -314,7 +314,7 @@ Parse CLI JSON output per `outputMode` (see `shared/output-mode.md`).
 ```bash
 $CMD_PREFIX create \
   --prompt "a serene mountain lake at dawn" \
-  --model "gemini-3-pro-image-preview" \
+  --model "gemini-3-pro-image" \
   --lang en \
   --aspect-ratio 16:9 \
   --size 2K \


### PR DESCRIPTION
## Summary
- Update image-gen skill model choices and CLI examples to GA Gemini image IDs.
- Update creator/avatar templates that hard-coded the old preview model.

## Validation
- git diff --check

Part of marswaveai/listenhub-ralph#179