### PR TITLE
docs(video-gen): 加 PixVerse 模型 + lipsync 能力

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [1.3.0] - 2026-06-25
+
+### Enhancement
+
+**Added:**
+- `video-gen/` — PixVerse as a third model family (`listenhub openapi video pixverse generate`). Nine atomic capabilities: text_to_video, image_to_video, transition, multi_transition, fusion, restyle, mimic, lip_sync, agent. Introduces **lip sync** (PixVerse-only, audio or TTS), mimic (locked 720p), the marketing agent (ad_master/promo_mix, 720p/1080p + 20/30/60), and fusion `@refName` prompt syntax.
+- `video-gen/references/pixverse-api.md` — dedicated PixVerse reference (capability list, capability→flag mapping, per-capability parameter tables, constraints, output format).
+- `video-gen/SKILL.md` — Step 3d lip-sync collection block, PixVerse command templates (generate + estimate), PixVerse option in the model picker, PixVerse examples, Lipsync row in the Model Comparison table.
+
+**Changed:**
+- `listenhub/SKILL.md` + `listenhub-cli/SKILL.md` — added `pixverse`, `口型`, `lipsync`, `对口型` trigger words routing to `/video-gen`.
+- `video-gen/SKILL.md` — corrected SeeDance rate limit to 5 RPM (was stale at 2; aligned with HappyHorse via #243).
+
 ## [1.2.0] - 2026-05-20
 
 ### New Skill

--- a/listenhub-cli/SKILL.md
+++ b/listenhub-cli/SKILL.md
@@ -5,7 +5,8 @@ description: |
   Triggers on: "make a podcast", "explainer video", "read aloud", "TTS",
   "generate image", "generate video", "做播客", "解说视频", "朗读", "生成图片",
   "生成视频", "幻灯片", "slides", "音乐", "music", "generate music", "翻唱",
-  "cover song", "parse URL", "解析链接", "提取内容".
+  "cover song", "pixverse", "口型", "lipsync", "对口型",
+  "parse URL", "解析链接", "提取内容".
 metadata:
   openclaw:
     emoji: "🎧"
@@ -27,7 +28,7 @@ This is a router skill. When users trigger a general ListenHub action, this skil
 | Slides / PPT | "slides", "幻灯片", "PPT", "presentation" | `/slides` |
 | TTS / Read aloud | "TTS", "read aloud", "朗读", "配音", "语音合成" | `/tts` |
 | Image generation | "generate image", "画一张", "生成图片", "AI图" | `/image-gen` |
-| Video generation | "video", "视频", "seedance", "生成视频", "text to video", "做视频" | `/video-gen` |
+| Video generation | "video", "视频", "seedance", "pixverse", "生成视频", "text to video", "做视频", "口型", "lipsync", "对口型" | `/video-gen` |
 | Music | "music", "音乐", "生成音乐", "翻唱", "cover" | `/music` |
 | Content extraction | "parse URL", "extract content", "解析链接" | `/content-parser` |
 | Audio transcription | "transcribe", "ASR", "语音转文字" | `/asr` |

--- a/listenhub/SKILL.md
+++ b/listenhub/SKILL.md
@@ -7,7 +7,8 @@ description: |
   "生成视频", "幻灯片", "slides", "音乐", "music", "generate music", "翻唱",
   "混音", "remix", "续写", "extend", "纯音乐", "instrumental", "配乐",
   "soundtrack", "分轨", "stem", "识别歌词", "克隆人声", "vocal clone",
-  "cover song", "parse URL", "解析链接", "提取内容".
+  "cover song", "pixverse", "口型", "lipsync", "对口型",
+  "parse URL", "解析链接", "提取内容".
 metadata:
   openclaw:
     emoji: "🎧"
@@ -29,7 +30,7 @@ This is a router skill. When users trigger a general ListenHub action, this skil
 | Slides / PPT | "slides", "幻灯片", "PPT", "presentation" | `/slides` |
 | TTS / Read aloud | "TTS", "read aloud", "朗读", "配音", "语音合成" | `/tts` |
 | Image generation | "generate image", "画一张", "生成图片", "AI图" | `/image-gen` |
-| Video generation | "video", "视频", "seedance", "生成视频", "text to video", "做视频" | `/video-gen` |
+| Video generation | "video", "视频", "seedance", "pixverse", "生成视频", "text to video", "做视频", "口型", "lipsync", "对口型" | `/video-gen` |
 | Music | "music", "音乐", "生成音乐", "翻唱", "混音", "remix", "续写", "extend", "纯音乐", "instrumental", "配乐", "soundtrack", "分轨", "stem", "识别歌词", "克隆人声", "vocal clone" | `/music` |
 | Content extraction | "parse URL", "extract content", "解析链接" | `/content-parser` |
 | Audio transcription | "transcribe", "ASR", "语音转文字" | `/asr` |

--- a/video-gen/SKILL.md
+++ b/video-gen/SKILL.md
@@ -8,9 +8,10 @@ metadata:
     primaryBin: "listenhub"
 description: |
   Generate AI videos from text prompts or reference materials.
-  Supports HappyHorse and SeeDance models.
+  Supports HappyHorse, SeeDance, and PixVerse models.
   Triggers on: "生成视频", "做视频", "video generation", "text to video",
-  "create video", "视频生成", "视频编辑", "video edit".
+  "create video", "视频生成", "视频编辑", "video edit", "pixverse",
+  "口型", "lipsync", "对口型".
 ---
 
 ## When to Use
@@ -19,7 +20,9 @@ description: |
 - User wants to animate a still image (first-frame)
 - User has reference images to guide video generation
 - User wants to edit an existing video (change style, background, etc.)
-- User says "生成视频", "做视频", "video generation", "text to video", "视频编辑"
+- User wants to lip-sync a video to audio or TTS (PixVerse only) — "对口型", "口型同步"
+- User wants a marketing ad / promo mix video (PixVerse agent)
+- User says "生成视频", "做视频", "video generation", "text to video", "视频编辑", "pixverse", "口型"
 
 ## When NOT to Use
 
@@ -29,10 +32,11 @@ description: |
 
 ## Purpose
 
-Generate AI videos using the ListenHub CLI. Supports two model families:
+Generate AI videos using the ListenHub CLI. Supports three model families:
 
 - **HappyHorse** (default) — text-to-video, image-to-video, reference-image-to-video, video-edit
 - **SeeDance** — text-to-video, frame mode (first + last frame), reference mode (images, videos, audio)
+- **PixVerse** — nine atomic capabilities via the Agent API (text_to_video, image_to_video, transition, multi_transition, fusion, restyle, mimic, **lip_sync**, agent). The only family that supports lip sync. OpenAPI-only (URLs required) and uses its own `pixverse` CLI namespace.
 
 ## Hard Constraints
 
@@ -53,18 +57,27 @@ until the user has explicitly confirmed.
 
 ## Model Comparison
 
-| Feature | HappyHorse (default) | SeeDance |
-|---------|---------------------|----------|
-| Text-to-video | ✅ | ✅ |
-| Image-to-video (first-frame) | ✅ | ✅ (+ last-frame) |
-| Reference images | ✅ (1–9, with [Image N] prompt syntax) | ✅ |
-| Video edit | ✅ | ❌ |
-| Reference video | ❌ (use video-edit instead) | ✅ |
-| Reference audio | ❌ | ✅ |
-| Resolution | 720p, 1080p | 480p, 720p, 1080p |
-| Duration range | 3–15s | 4–15s |
-| Extra ratios | 4:5, 5:4 | — |
-| Prompt length | ≤2500 中文 / ≤5000 非中文 | ≤500 |
+| Feature | HappyHorse (default) | SeeDance | PixVerse |
+|---------|---------------------|----------|----------|
+| Text-to-video | ✅ | ✅ | ✅ (`text_to_video`) |
+| Image-to-video (first-frame) | ✅ | ✅ (+ last-frame) | ✅ (`image_to_video`) |
+| Reference images | ✅ (1–9, with [Image N] prompt syntax) | ✅ | ✅ (`fusion`, `@refName` syntax) |
+| Transition (first→last) | ❌ | ✅ (frame mode) | ✅ (`transition` / `multi_transition`) |
+| Video edit | ✅ | ❌ | ❌ |
+| Restyle | ❌ | ❌ | ✅ (`restyle`) |
+| Mimic (motion transfer) | ❌ | ❌ | ✅ (`mimic`, locked 720p) |
+| **Lip sync** | ❌ | ❌ | ✅ (`lip_sync`, audio or TTS) |
+| Marketing agent (ad/promo) | ❌ | ❌ | ✅ (`agent`: ad_master / promo_mix) |
+| Reference video | ❌ (use video-edit instead) | ✅ | ✅ (mimic / lip_sync source) |
+| Reference audio | ❌ | ✅ | ✅ (lip_sync) |
+| Resolution / quality | 720p, 1080p | 480p, 720p, 1080p | 360p, 540p, 720p, 1080p |
+| Duration range | 3–15s | 4–15s | 1–60s (agent: 20/30/60) |
+| Aspect ratios | 16:9, 9:16, 1:1, 4:3, 3:4, 4:5, 5:4 | 16:9, 9:16, 1:1, 4:3, 3:4, 21:9 | 9:16, 16:9, 1:1, 4:3, 3:4 |
+| Prompt length | ≤2500 中文 / ≤5000 非中文 | ≤500 | ≤2048 |
+| Rate limit | 5 RPM | 5 RPM | 5 RPM |
+| CLI namespace | `… video create` | `… video create` | `… video pixverse generate` (OpenAPI only) |
+
+**Lip sync is PixVerse-only** — HappyHorse and SeeDance do not support it. Mimic, restyle, fusion, transition, and the marketing agent are also PixVerse-exclusive.
 
 ## Step -1: CLI Auth Check + Video Command Gate
 
@@ -119,6 +132,7 @@ All subsequent commands use `$CMD_PREFIX` instead of hardcoded `listenhub video`
 - OpenAPI mode requires API Key (`lh_sk_...`), configured via `listenhub openapi config set-key` or env `LISTENHUB_API_KEY`
 - OpenAPI mode does not support `--audio-setting` flag (video-edit audio control not yet exposed)
 - All media inputs must be **URLs** in OpenAPI mode (no local file upload) — if user provides local paths, inform them: "OpenAPI 模式需要使用公网 URL，请先上传文件后提供链接。"
+- **PixVerse is OpenAPI-only** — it lives under `listenhub openapi video pixverse` and has no internal-auth equivalent. If the user wants PixVerse (口型/mimic/restyle/fusion/transition/agent) but only internal auth is configured, prompt them to configure an OpenAPI key first.
 
 ## Step 0: Config Setup
 
@@ -185,7 +199,10 @@ Options:
   - "有图片，想做首帧动画" — Image-to-video (first-frame) → Step 3a
   - "有参考图片（风格/角色参考）" — Reference-image mode → Step 3b
   - "有视频，想编辑/修改" — Video-edit mode → Step 3c
+  - "有视频，想做口型同步" — Lip-sync mode (PixVerse only) → Step 3d
 ```
+
+If the user mentions PixVerse-exclusive capabilities (口型/lip sync, 模仿/mimic, restyle/风格化、融合/fusion、过渡/transition、广告/promo agent), route to PixVerse and pick the matching `--capability` — see Step 4 (PixVerse) and `references/pixverse-api.md`.
 
 ### Step 3a: Image-to-Video (First-Frame)
 
@@ -248,6 +265,33 @@ After collecting, proceed to Step 4.
 
 **Note:** Video-edit has no `ratio` or `duration` parameters — output matches input video.
 
+### Step 3d: Lip-Sync Mode (PixVerse Only)
+
+Lip sync is **only available on PixVerse** (`--capability lip_sync`). If the user is on HappyHorse/SeeDance, inform them: "口型同步仅 PixVerse 模型支持，已自动切换。" and use the PixVerse command template in Step 4.
+
+1. **source video** (required): the video whose lips will be driven. Collect EITHER:
+   - `--source-video-id <id>` — a PixVerse video id, OR
+   - `--source-task-id <id>` — a prior succeeded PixVerse task to reuse.
+
+   (OpenAPI-only; the source must already exist on PixVerse.)
+
+2. **audio source** — ask the user which drive method:
+
+```
+Question: "口型用什么驱动？"
+Options:
+  - "用一段音频文件" — Collect 1 audio URL → --audio <url>
+  - "用文字转语音 (TTS)" — Collect speaker + content → --pixverse-json '{"tts":{...}}'
+```
+
+   - **Audio file:** collect one public audio URL → `--audio <url>` (max 1)，音频时长须落在 5–60s。
+   - **TTS:** collect a speaker id and the text to speak，走嵌套 JSON（**不要**用 `--lip-sync-*` flag，详见 `references/pixverse-api.md` § lip_sync）：
+     - `--pixverse-json '{"tts":{"speakerId":"<id>","content":"<text>"}}'`
+
+   Do NOT mix audio and TTS — pick one（同时给两者会被契约拒绝）。
+
+After collecting, proceed to Step 4 (use the PixVerse `lip_sync` template).
+
 ### Step 4: Optional Parameter Adjustment
 
 Read session defaults and present. Adjust display based on mode:
@@ -279,7 +323,10 @@ Options:
   - "happyhorse（推荐）" — Higher quality, video-edit support
   - "doubao-seedance-2-pro" — SeeDance pro, supports last-frame & audio ref
   - "doubao-seedance-2-fast" — SeeDance fast
+  - "pixverse" — PixVerse: 口型同步/模仿/风格化/融合/过渡/广告 agent (OpenAPI only)
 ```
+
+If the user picks **pixverse**, switch to the PixVerse command templates below — PixVerse uses its own `… video pixverse generate` namespace, an explicit `--capability`, and `--quality`/`--aspect-ratio` instead of `--resolution`/`--ratio`. See "PixVerse Command Templates" and `references/pixverse-api.md`.
 
 **Resolution:**
 ```
@@ -462,6 +509,127 @@ RESULT=$($CMD_PREFIX create \
 EXIT_CODE=$?
 ```
 
+### PixVerse Command Templates
+
+PixVerse uses its own namespace and an explicit `--capability`. It is **OpenAPI-only**, so `$CMD_PREFIX` must be `listenhub openapi video` — invoke `… pixverse generate` (not `… create`). All media inputs are **URLs**. Quality uses `--quality` (360p/540p/720p/1080p) and ratio uses `--aspect-ratio` (9:16/16:9/1:1/4:3/3:4); there is no `--resolution`/`--ratio` here.
+
+**text_to_video:**
+```bash
+RESULT=$(listenhub openapi video pixverse generate \
+  --capability text_to_video \
+  --model pixverse \
+  --prompt "赛博朋克城市夜景" \
+  --quality 720p \
+  --aspect-ratio 16:9 \
+  --duration 5 \
+  --no-wait --json 2>/tmp/lh-err)
+EXIT_CODE=$?
+```
+
+**image_to_video:**
+```bash
+RESULT=$(listenhub openapi video pixverse generate \
+  --capability image_to_video \
+  --model pixverse \
+  --prompt "让画面里的人物自然走动" \
+  --image "https://example.com/scene.png" \
+  --quality 720p \
+  --aspect-ratio 16:9 \
+  --duration 5 \
+  --no-wait --json 2>/tmp/lh-err)
+EXIT_CODE=$?
+```
+
+**lip_sync (audio file):** source video + 1 audio URL.
+```bash
+RESULT=$(listenhub openapi video pixverse generate \
+  --capability lip_sync \
+  --source-video-id "abc123" \
+  --audio "https://example.com/voice.mp3" \
+  --quality 720p \
+  --no-wait --json 2>/tmp/lh-err)
+EXIT_CODE=$?
+```
+
+**lip_sync (TTS):** source video + nested `tts`（do NOT also pass `--audio`）。TTS 必须走 `--pixverse-json` 的嵌套 `tts`，**不要**用 `--lip-sync-tts/--lip-sync-speaker-id/--lip-sync-content`（那三个 flag 映射到 `lipSyncTts*`，校验器/provider 不认，会被拒绝——上游 listenhub-cli #250 的 flag→字段错配）。
+```bash
+RESULT=$(listenhub openapi video pixverse generate \
+  --capability lip_sync \
+  --source-task-id "task_xyz" \
+  --pixverse-json '{"tts":{"speakerId":"speaker_01","content":"大家好，欢迎来到本期节目"}}' \
+  --quality 720p \
+  --no-wait --json 2>/tmp/lh-err)
+EXIT_CODE=$?
+```
+
+**mimic:** 1 image + 1 video, quality **locked to 720p**.
+```bash
+RESULT=$(listenhub openapi video pixverse generate \
+  --capability mimic \
+  --image "https://example.com/subject.png" \
+  --video "https://example.com/motion.mp4" \
+  --quality 720p \
+  --no-wait --json 2>/tmp/lh-err)
+EXIT_CODE=$?
+```
+
+**agent (ad_master / promo_mix):** quality 720p/1080p only, duration 20/30/60 only; `promo_mix` needs ≥4 images.
+```bash
+RESULT=$(listenhub openapi video pixverse generate \
+  --capability agent \
+  --agent-type promo_mix \
+  --prompt "为这款耳机做一支 30 秒带货短片" \
+  --image "https://example.com/p1.png" \
+  --image "https://example.com/p2.png" \
+  --image "https://example.com/p3.png" \
+  --image "https://example.com/p4.png" \
+  --quality 1080p \
+  --duration 30 \
+  --no-wait --json 2>/tmp/lh-err)
+EXIT_CODE=$?
+```
+
+**fusion:** 参考图走嵌套 `imageReferences`（**不要**用 top-level `--image`，否则契约 `any.invalid` 拒绝）；prompt 须为每个 `refName` 写 `@refName`。`type` 取 `subject`/`background`，`refName` 须匹配 `/^[A-Za-z][A-Za-z0-9_]{0,31}$/`。
+```bash
+RESULT=$(listenhub openapi video pixverse generate \
+  --capability fusion \
+  --prompt "让 @cat 在 @city 的街道上奔跑" \
+  --pixverse-json '{"imageReferences":[{"type":"subject","imageUrl":"https://example.com/cat.png","refName":"cat"},{"type":"background","imageUrl":"https://example.com/city.png","refName":"city"}]}' \
+  --quality 720p \
+  --no-wait --json 2>/tmp/lh-err)
+EXIT_CODE=$?
+```
+
+**multi_transition:** 关键帧走嵌套 `multiTransition`（2–7 个 `{imageUrl,duration,prompt}`；**不要**用 top-level `--image`），默认 quality 360p。
+```bash
+RESULT=$(listenhub openapi video pixverse generate \
+  --capability multi_transition \
+  --pixverse-json '{"multiTransition":[{"imageUrl":"https://example.com/k1.png","duration":3,"prompt":"清晨的城市"},{"imageUrl":"https://example.com/k2.png","duration":3,"prompt":"正午的广场"},{"imageUrl":"https://example.com/k3.png","duration":3,"prompt":"夜晚的霓虹"}]}' \
+  --quality 360p \
+  --no-wait --json 2>/tmp/lh-err)
+EXIT_CODE=$?
+```
+
+**PixVerse capability constraints (enforce before submitting):**
+- `mimic` — quality **locked 720p** (other values rejected); needs 1 image + 1 video，运动源视频时长 **5–30s**。
+- `agent` — quality **720p/1080p only**, duration **20/30/60 only**; `promo_mix` requires **≥4 images**.
+- `multi_transition` — 关键帧走 `--pixverse-json` 的 `multiTransition[]`（2–7 个），top-level `--image` **必须为空**；default quality **360p**。
+- `fusion` — 参考图走 `--pixverse-json` 的 `imageReferences[]`（1–8 个），top-level `--image` **必须为空**；prompt 须为每个 `refName` 写 `@refName`。
+- `lip_sync` — source video (`--source-video-id`/`--source-task-id`) + EITHER 1 `--audio`（5–60s）OR nested `tts`（`--pixverse-json '{"tts":{...}}'`，**勿用 `--lip-sync-*` flag**）；二者不能同时给。
+- `restyle` — `--source-video-id` (or `--source-task-id`) + `--restyle-id`.
+
+**PixVerse estimate** (mirror the generate capability + quality/duration):
+```bash
+ESTIMATE=$(listenhub openapi video pixverse estimate \
+  --capability text_to_video \
+  --model pixverse \
+  --quality 720p \
+  --duration 5 \
+  --json 2>/tmp/lh-err)
+EXIT_CODE=$?
+```
+For `agent` add `--agent-type ad_master` (or `promo_mix`).
+
 **Flags only when needed:**
 - `--no-generate-audio` — only if user disabled audio (SeeDance only)
 - `--seed 12345` — only if user specified a seed
@@ -589,6 +757,7 @@ Reuse `shared/cli-patterns.md` standard error codes:
 - Config pattern: `shared/config-pattern.md`
 - Output mode: `shared/output-mode.md`
 - HappyHorse API: `references/happyhorse-api.md`
+- PixVerse API: `references/pixverse-api.md`
 
 ## Composability
 
@@ -671,5 +840,46 @@ listenhub video create \
   --duration 8 \
   --first-frame "/path/to/day.png" \
   --last-frame "/path/to/night.png" \
+  --no-wait --json
+```
+
+### Text-to-video (PixVerse)
+
+> "用 pixverse 生成一个视频：海边日落延时"
+
+```bash
+listenhub openapi video pixverse generate \
+  --capability text_to_video \
+  --model pixverse \
+  --prompt "海边日落延时，云层快速移动" \
+  --quality 720p \
+  --aspect-ratio 16:9 \
+  --duration 5 \
+  --no-wait --json
+```
+
+### Lip-sync (PixVerse, TTS)
+
+> "把这个视频做口型同步，让人物说这段话"
+
+```bash
+listenhub openapi video pixverse generate \
+  --capability lip_sync \
+  --source-video-id "abc123" \
+  --pixverse-json '{"tts":{"speakerId":"speaker_01","content":"大家好，欢迎来到本期节目"}}' \
+  --quality 720p \
+  --no-wait --json
+```
+
+### Lip-sync (PixVerse, audio file)
+
+> "用这段音频给视频对口型"
+
+```bash
+listenhub openapi video pixverse generate \
+  --capability lip_sync \
+  --source-task-id "task_xyz" \
+  --audio "https://example.com/voice.mp3" \
+  --quality 720p \
   --no-wait --json
 ```

--- a/video-gen/references/pixverse-api.md
+++ b/video-gen/references/pixverse-api.md
@@ -1,0 +1,180 @@
+# PixVerse Video Model Reference
+
+PixVerse is exposed through a dedicated **Agent API** with nine atomic capabilities (plus a marketing agent). Unlike HappyHorse/SeeDance — which infer the sub-mode from the inputs — PixVerse requires an explicit `--capability` and uses its own CLI namespace:
+
+```
+listenhub openapi video pixverse generate --capability <cap> ...
+listenhub openapi video pixverse estimate --capability <cap> ...
+```
+
+PixVerse is **OpenAPI-only** (`lh_sk_...` key) and all media inputs must be **public URLs** (no local file upload).
+
+## Capabilities
+
+| Capability | Description | Required inputs |
+|------------|-------------|-----------------|
+| `text_to_video` | Pure text prompt generation | prompt |
+| `image_to_video` | Animate a still image | 1 image + prompt |
+| `transition` | Single first→last transition | 2 images (first + last) |
+| `multi_transition` | Multi-keyframe transition | `--pixverse-json` 携带 `multiTransition[]`（2–7 个关键帧；top-level `--image` 必须为空，默认 quality 360p） |
+| `fusion` | Reference-image fusion with `@refName` prompt syntax | `--pixverse-json` 携带 `imageReferences[]`（1–8 个，每个 `{type,imageUrl,refName}`；prompt 须为每个 refName 写 `@refName`；top-level `--image` 必须为空） |
+| `restyle` | Restyle a prior PixVerse video | `--source-video-id` (or `--source-task-id`) + `--restyle-id` |
+| `mimic` | Mimic a video's motion onto an image | 1 image + 1 video (locked to 720p) |
+| `lip_sync` | Drive a video's lips from audio or TTS | source video (`--source-video-id`/`--source-task-id`) + EITHER 1 audio OR TTS（TTS 必须走 `--pixverse-json '{"tts":{"speakerId":"…","content":"…"}}'`，见下方说明）。audio 与 tts 二选一，不能同时给 |
+| `agent` | Marketing agent (ad_master / promo_mix) | `--agent-type`; quality 720p/1080p, duration 20/30/60 |
+
+## Capability → CLI Flag Mapping
+
+| Concept | CLI Flag | Notes |
+|---------|----------|-------|
+| capability | `--capability` | **required**, one of the nine above |
+| model | `--model` | `pixverse` (default), `v6`, `v5`, `v4.5` |
+| service region | `--language` | `zh` / `en` (default `en`) |
+| prompt | `--prompt` | max 2048 chars |
+| quality | `--quality` | `360p` / `540p` / `720p` / `1080p` (default `720p`) |
+| aspect ratio | `--aspect-ratio` | `9:16` / `16:9` / `1:1` / `4:3` / `3:4` (default `16:9`) |
+| duration | `--duration` | integer 1–60 (default 5) |
+| image asset | `--image <url[:duration]>` | repeatable, max 10（top-level images；**fusion / multi_transition 必须留空**，参考帧走 `--pixverse-json`） |
+| video asset | `--video <url[:duration]>` | repeatable, max 2 |
+| audio asset | `--audio <url[:duration]>` | repeatable, max 1 |
+| reuse prior task | `--source-task-id` | restyle / lip_sync source |
+| agent type | `--agent-type` | `ad_master` / `promo_mix` (capability=agent) |
+| restyle source video | `--source-video-id` | restyle / lip_sync |
+| restyle id | `--restyle-id` | restyle |
+| escape hatch | `--pixverse-json` | raw JSON for the nested `pixverse` object（fusion `imageReferences`、multi_transition `multiTransition`、lip_sync TTS `tts` 都靠它；dedicated flags override individual fields） |
+
+> `--lip-sync-tts/--lip-sync-speaker-id/--lip-sync-content` 三个 flag 当前映射到 `lipSyncTts*` 字段，校验器/provider 不认（见 `lip_sync` 小节），**勿用**；TTS 走 `--pixverse-json` 的嵌套 `tts`。
+
+Asset duration: append `:N` to a URL (e.g. `https://x.com/a.mp4:6`) to attach a per-asset duration in seconds; the URL may contain colons, only a trailing `:<integer>` is parsed as duration.
+
+## Parameters by Capability
+
+### `text_to_video`
+
+| Parameter | CLI Flag | Values | Default |
+|-----------|----------|--------|---------|
+| prompt | `--prompt` | ≤2048 chars | (required) |
+| quality | `--quality` | 360p / 540p / 720p / 1080p | 720p |
+| aspectRatio | `--aspect-ratio` | 9:16 / 16:9 / 1:1 / 4:3 / 3:4 | 16:9 |
+| duration | `--duration` | 1–60 | 5 |
+
+### `image_to_video`
+
+| Parameter | CLI Flag | Values | Default |
+|-----------|----------|--------|---------|
+| prompt | `--prompt` | ≤2048 chars | (recommended) |
+| image | `--image` | 1 image URL | (required) |
+| quality | `--quality` | 360p / 540p / 720p / 1080p | 720p |
+| aspectRatio | `--aspect-ratio` | 9:16 / 16:9 / 1:1 / 4:3 / 3:4 | 16:9 |
+| duration | `--duration` | 1–60 | 5 |
+
+### `transition`
+
+| Parameter | CLI Flag | Values | Default |
+|-----------|----------|--------|---------|
+| image | `--image` | 2 images (first + last, in order) | (required) |
+| prompt | `--prompt` | ≤2048 chars | (optional) |
+| quality | `--quality` | 360p / 540p / 720p / 1080p | 720p |
+| duration | `--duration` | 1–60 | 5 |
+
+### `multi_transition`
+
+关键帧不走 top-level `--image`。契约要求 `pixverse.multiTransition[]`，且 top-level images **必须为空**（否则 `any.invalid` 拒绝）。通过 `--pixverse-json` 逃生舱传：
+
+| Parameter | CLI Flag | Values | Default |
+|-----------|----------|--------|---------|
+| keyframes | `--pixverse-json` → `multiTransition[]` | 2–7 个，每个 `{imageUrl, duration, prompt}`（duration 为 0–30 整数，prompt 必填） | (required) |
+| quality | `--quality` | 360p / 540p / 720p / 1080p | **360p** |
+| duration | `--duration` | 1–60 | 5 |
+
+```bash
+--pixverse-json '{"multiTransition":[{"imageUrl":"https://example.com/k1.png","duration":3,"prompt":"第一段"},{"imageUrl":"https://example.com/k2.png","duration":3,"prompt":"第二段"}]}'
+```
+
+**Default quality is 360p** for multi_transition (override with `--quality` if needed). top-level `--image` 必须为空。
+
+### `fusion`
+
+参考图不走 top-level `--image`。契约要求 `pixverse.imageReferences[]`，且 top-level images **必须为空**（否则 `any.invalid` 拒绝）。通过 `--pixverse-json` 逃生舱传：
+
+| Parameter | CLI Flag | Values | Default |
+|-----------|----------|--------|---------|
+| references | `--pixverse-json` → `imageReferences[]` | 1–8 个，每个 `{type, imageUrl, refName}`；`type` 为 `subject`/`background`；`refName` 须匹配 `/^[A-Za-z][A-Za-z0-9_]{0,31}$/` | (required) |
+| prompt | `--prompt` | must contain `@refName` per reference | (required) |
+| quality | `--quality` | 360p / 540p / 720p / 1080p | 720p |
+| duration | `--duration` | 1–60 | 5 |
+
+```bash
+--pixverse-json '{"imageReferences":[{"type":"subject","imageUrl":"https://example.com/cat.png","refName":"cat"},{"type":"background","imageUrl":"https://example.com/city.png","refName":"city"}]}'
+```
+
+**Prompt `@refName` syntax:** every `imageReferences` entry must be referenced in the prompt with `@refName` (e.g. `让 @cat 在 @city 里奔跑`). Missing references are rejected by the contract. top-level `--image` 必须为空。
+
+### `restyle`
+
+| Parameter | CLI Flag | Values | Default |
+|-----------|----------|--------|---------|
+| source video | `--source-video-id` or `--source-task-id` | a prior PixVerse video | (required) |
+| restyle id | `--restyle-id` | a PixVerse restyle preset id | (required) |
+| prompt | `--prompt` | ≤2048 chars | (optional) |
+| quality | `--quality` | 360p / 540p / 720p / 1080p | 720p |
+
+### `mimic`
+
+| Parameter | CLI Flag | Values | Default |
+|-----------|----------|--------|---------|
+| image | `--image` | 1 image (subject) | (required) |
+| video | `--video <url[:duration]>` | 1 video (motion source)，时长 **5–30s** | (required) |
+| quality | `--quality` | **720p (locked)** | 720p |
+| duration | `--duration` | 1–60 | 5 |
+
+**Quality is locked to 720p** for mimic — other values are rejected (prevents pricing NaN). 运动源视频时长须落在 **5–30s**（用 `--video <url>:N` 附带每素材时长；超出区间被契约拒绝）。
+
+### `lip_sync`
+
+| Parameter | CLI Flag | Values | Default |
+|-----------|----------|--------|---------|
+| source video | `--source-video-id` or `--source-task-id` | the video to drive | (required) |
+| audio (option A) | `--audio <url[:duration]>` | 1 external audio URL，时长 **5–60s** | one of A/B required |
+| TTS (option B) | `--pixverse-json` → `tts` | `{"speakerId":"…","content":"…"}` | one of A/B required |
+| quality | `--quality` | 360p / 540p / 720p / 1080p | 720p |
+
+**Source + EITHER audio OR TTS:** supply a source video (`--source-video-id` or `--source-task-id`) plus *either* one external audio file *or* nested TTS. 二选一，**不能同时给 audio 和 tts**（契约 `audioCount===1 && pixverse.tts` 直接拒绝）。
+
+⚠️ **TTS 必须走 `--pixverse-json` 的嵌套 `tts` 字段，不要用 `--lip-sync-tts/--lip-sync-speaker-id/--lip-sync-content`。** 那三个 flag 在当前 CLI 里映射到 `lipSyncTtsSwitch/lipSyncTtsSpeakerId/lipSyncTtsContent`，而 lip_sync 校验器与 provider 只认嵌套的 `pixverse.tts={speakerId,content}`，所以那条路径端到端不通（无 audio + 无 `pixverse.tts` → `any.invalid`）。这是上游 listenhub-cli #250 的 flag→字段错配，待 CLI 修复前一律用 `--pixverse-json`：
+
+```bash
+--pixverse-json '{"tts":{"speakerId":"speaker_01","content":"大家好，欢迎来到本期节目"}}'
+```
+
+audio 须落在 **5–60s**（用 `--audio <url>:N` 附带时长；超出区间被契约拒绝）。
+
+### `agent`
+
+| Parameter | CLI Flag | Values | Default |
+|-----------|----------|--------|---------|
+| agent type | `--agent-type` | `ad_master` / `promo_mix` | (required) |
+| image | `--image` | source materials (`promo_mix` requires ≥4) | per type |
+| prompt | `--prompt` | brief / product description | (recommended) |
+| quality | `--quality` | **720p / 1080p only** | 720p |
+| duration | `--duration` | **20 / 30 / 60 only** | per type |
+
+**Agent constraints:** quality is restricted to 720p/1080p and duration to 20/30/60. `promo_mix` requires **≥4 images**.
+
+## Input Asset Constraints
+
+- All assets are **public URLs** (OpenAPI mode — no local upload).
+- Images: max 10 (`--image`, repeatable).
+- Videos: max 2 (`--video`, repeatable).
+- Audio: max 1 (`--audio`).
+- Per-asset duration: append `:<seconds>` to the URL.
+
+## Rate Limit
+
+5 RPM per user (aligned with SeeDance).
+
+## Output
+
+- Format: MP4 (H.264).
+- Result is polled with `listenhub openapi video get <taskId> --json` (PixVerse tasks share the standard video task store).
+- URL valid for a limited window — download promptly.


### PR DESCRIPTION
## 背景

PixVerse 已接入公开 Agent OpenAPI 层（api-server#779）+ SDK（sdk#20）+ CLI（cli#18）。本 PR 把 PixVerse 作为第三个模型族补进 video-gen skill，并新增 lipsync 能力脚手架（此前所有模型都缺）。

## 改动

- `video-gen/SKILL.md`：PixVerse 加进描述/When-to-Use/Purpose/Model Comparison 表（capability、quality 360p-1080p、duration 1-60、5 RPM）；Step 4 模型选择加 pixverse；新增 PixVerse 命令模板段（用 CLI 实际 flag，覆盖 text_to_video/image_to_video/lip_sync/mimic/agent/fusion/multi_transition）+ 各能力约束
- **lipsync 脚手架**：Step 2 路由加"口型同步"、Step 3d 采集块（source video + audio 或 TTS）、Model Comparison 加 Lipsync 行，明确 PixVerse-only
- **新建** `video-gen/references/pixverse-api.md`：镜像 happyhorse-api.md 结构（capability→flag 映射、各能力参数表、约束、资产上限、输出格式），SKILL.md 4 处链接
- `listenhub/SKILL.md` + `listenhub-cli/SKILL.md`：router trigger 加 pixverse/口型/lipsync/对口型
- `CHANGELOG.md`：[1.3.0] 条目
- Seedance RPM 同步为 5

## 对抗验证修正（抓到真实契约错误）

- **fusion**：必须走 `--pixverse-json` 的 `imageReferences[]`（{type,imageUrl,refName}），top-level `--image` 必须为空，prompt 含 @refName（初稿误用 --image 会被 any.invalid 拒）
- **multi_transition**：必须走 `--pixverse-json` 的 `multiTransition[]`（2-7 keyframes），top-level --image 必须为空
- **lip_sync TTS**：文档改用 `--pixverse-json '{"tts":{"speakerId":...,"content":...}}'`（校验器认嵌套 pixverse.tts），并标注 `--lip-sync-*` flag 的局限 + audio XOR tts
- 补 mimic 视频 5-30s / lip_sync 音频 5-60s 时长窗

## 注意

skill 实际可跑依赖 CLI 发布（`@marswave/listenhub-cli@latest`）。文档为 doc-only（markdown，无编译），按 CLI 实际 flag + api-server 契约逐项核对。