### PR TITLE
docs(listenhub-voice): #240 README 补 listenhub-voice 并统一置于播客之前

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Turn ideas into videos, podcasts, and more. Powered by [ListenHub](https://liste
 
 | Skill | Trigger | What it does |
 |-------|---------|-------------|
+| `/listenhub-voice` | "生成音频", "语音生成", "端到端音频", "图片转音频" | End-to-end audio: sound effects, multi-voice dialogue, reference-audio cloning, image→audio |
 | `/podcast` | "make a podcast", "播客" | Generate podcast episodes (solo, dialogue, debate) |
 | `/explainer` | "explainer video", "解说视频" | Narrated explainer videos with AI visuals |
 | `/slides` | "slides", "幻灯片" | Create slide decks with AI visuals |
@@ -77,6 +78,7 @@ listenhub auth login
 ├── shared/              # Shared infrastructure (auth, CLI patterns)
 │
 │   # ListenHub
+├── listenhub-voice/     # End-to-end audio generation
 ├── podcast/             # Podcast generation
 ├── explainer/           # Explainer videos
 ├── slides/              # Slide decks

--- a/README.zh.md
+++ b/README.zh.md
@@ -43,6 +43,7 @@ git pull origin main
 
 | 技能 | 触发词 | 功能 |
 |------|--------|------|
+| `/listenhub-voice` | "生成音频"、"语音生成"、"端到端音频"、"图片转音频" | 端到端音频：音效、多音色对白、参考音频克隆、图片转音频 |
 | `/podcast` | "做播客"、"podcast" | 生成播客单集（独白、对话、辩论） |
 | `/explainer` | "解说视频"、"explainer video" | 带 AI 配图的解说视频 |
 | `/slides` | "幻灯片"、"slides" | AI 配图的演示文稿 |
@@ -77,6 +78,7 @@ listenhub auth login
 ├── shared/              # 公共基础设施（认证、CLI 模式）
 │
 │   # ListenHub
+├── listenhub-voice/     # 端到端音频生成
 ├── podcast/             # 播客生成
 ├── explainer/           # 解说视频
 ├── slides/              # 演示文稿

--- a/listenhub-cli/SKILL.md
+++ b/listenhub-cli/SKILL.md
@@ -23,11 +23,11 @@ This is a router skill. When users trigger a general ListenHub action, this skil
 
 | User intent | Keywords | Route to |
 |-------------|----------|----------|
+| ListenHub Voice end-to-end audio | "端到端音频", "语音生成", "图片转音频", "图片生成音频", "多音色对白", "参考音频克隆", "克隆音色", "音效", "生成音效" | `/listenhub-voice` |
 | Podcast | "podcast", "播客", "debate", "dialogue" | `/podcast` |
 | Explainer video | "explainer", "解说视频", "tutorial video" | `/explainer` |
 | Slides / PPT | "slides", "幻灯片", "PPT", "presentation" | `/slides` |
 | TTS / Read aloud | "TTS", "read aloud", "朗读", "配音", "语音合成" | `/tts` |
-| ListenHub Voice end-to-end audio | "端到端音频", "语音生成", "图片转音频", "图片生成音频", "多音色对白", "参考音频克隆", "克隆音色", "音效", "生成音效" | `/listenhub-voice` |
 | Image generation | "generate image", "画一张", "生成图片", "AI图" | `/image-gen` |
 | Video generation | "video", "视频", "seedance", "pixverse", "生成视频", "text to video", "做视频", "口型", "lipsync", "对口型" | `/video-gen` |
 | Music | "music", "音乐", "生成音乐", "翻唱", "cover" | `/music` |
@@ -46,12 +46,12 @@ If the intent is ambiguous, ask the user to clarify:
 ```
 Question: "What would you like to create?"
 Options:
+  - "ListenHub Voice" — End-to-end audio: sound effects, multi-voice dialogue, reference-audio cloning, image→audio
   - "Podcast" — Audio discussion on a topic
   - "Explainer Video" — Narrated video with AI visuals
   - "Slides" — Slide deck / presentation
   - "Music" — AI-generated music or cover
   - "Video" — AI video generation from text or reference materials
-  - "ListenHub Voice" — End-to-end audio: sound effects, multi-voice dialogue, reference-audio cloning, image→audio
 ```
 
 ## Prerequisites

--- a/listenhub/SKILL.md
+++ b/listenhub/SKILL.md
@@ -25,11 +25,11 @@ This is a router skill. When users trigger a general ListenHub action, this skil
 
 | User intent | Keywords | Route to |
 |-------------|----------|----------|
+| ListenHub Voice end-to-end audio | "端到端音频", "语音生成", "图片转音频", "图片生成音频", "多音色对白", "参考音频克隆", "克隆音色", "音效", "生成音效" | `/listenhub-voice` |
 | Podcast | "podcast", "播客", "debate", "dialogue" | `/podcast` |
 | Explainer video | "explainer", "解说视频", "tutorial video" | `/explainer` |
 | Slides / PPT | "slides", "幻灯片", "PPT", "presentation" | `/slides` |
 | TTS / Read aloud | "TTS", "read aloud", "朗读", "配音", "语音合成" | `/tts` |
-| ListenHub Voice end-to-end audio | "端到端音频", "语音生成", "图片转音频", "图片生成音频", "多音色对白", "参考音频克隆", "克隆音色", "音效", "生成音效" | `/listenhub-voice` |
 | Image generation | "generate image", "画一张", "生成图片", "AI图" | `/image-gen` |
 | Video generation | "video", "视频", "seedance", "pixverse", "生成视频", "text to video", "做视频", "口型", "lipsync", "对口型" | `/video-gen` |
 | Music | "music", "音乐", "生成音乐", "翻唱", "混音", "remix", "续写", "extend", "纯音乐", "instrumental", "配乐", "soundtrack", "分轨", "stem", "识别歌词", "克隆人声", "vocal clone" | `/music` |
@@ -48,12 +48,12 @@ If the intent is ambiguous, ask the user to clarify:
 ```
 Question: "What would you like to create?"
 Options:
+  - "ListenHub Voice" — End-to-end audio: sound effects, multi-voice dialogue, reference-audio cloning, image→audio
   - "Podcast" — Audio discussion on a topic
   - "Explainer Video" — Narrated video with AI visuals
   - "Slides" — Slide deck / presentation
   - "Music" — AI music: generate, remix, instrumental, soundtrack, stem, vocal clone
   - "Video" — AI video generation from text or reference materials
-  - "ListenHub Voice" — End-to-end audio: sound effects, multi-voice dialogue, reference-audio cloning, image→audio
 ```
 
 ## Prerequisites


### PR DESCRIPTION
## 背景

#240 的 `listenhub-voice` skill 已合入 main（`listenhub-voice/SKILL.md`），且两个 router skill 已把 `/listenhub-voice` 接入路由。但仓库 README 一直漏了这个 skill——技能表和目录结构树里都没有它。同时补齐时统一把 ListenHub Voice 排到 AI 播客之前，与前端 fumadocs（website-fe PR #514）保持一致。

## 改动

- `README.md` / `README.zh.md`
  - 技能表新增 `/listenhub-voice` 行，排在 `/podcast` 前
  - 目录结构树补 `listenhub-voice/`，排在 `podcast/` 前
- `listenhub/SKILL.md` / `listenhub-cli/SKILL.md`
  - 路由表与 AskUserQuestion 选项里 ListenHub Voice 从播客之后挪到之前（关键词路由不受顺序影响，纯排序对齐）

纯 README/文档改动，无 skill 逻辑变更。skills 为纯文档仓（无 build/lint/test），已结构核对：两处 README 中 `/listenhub-voice` 均在 `/podcast` 前，两 router 各保留 1 路由行 + 1 选项、Voice 均在 Podcast 前。

关联前端文档 PR：marswaveai/listenhub-website-fe#514

🤖 Generated with [Claude Code](https://claude.com/claude-code)