### PR TITLE
feat(#646): document task-level generation speed in podcast and TTS skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Enhancement
+
+**Changed:**
+- `podcast/SKILL.md` + `tts/SKILL.md` — support a task-level generation speed via the CLI's `--speed` flag. Continuous `0.5`–`2.0` range with at most two decimals; common values are `0.5 / 0.75 / 1 / 1.25 / 1.5 / 2`. The skills never ask about speed: with no explicit user request they omit the flag and generation stays at `1` (original speed).
+
 ## [1.4.0] - 2026-07-30
 
 ### New Skill

--- a/podcast/SKILL.md
+++ b/podcast/SKILL.md
@@ -172,6 +172,25 @@ Follow `shared/speaker-selection.md`:
 
 For 2-speaker mode (dialogue/debate): use Primary + Secondary defaults for the language.
 
+### Step 5.5: Generation Speed
+
+**Default: 1.0x (original speed). Never ask this question.**
+
+Only set a speed when the user explicitly asks for one — "慢一点"、"快一点"、"1.25 倍速"、
+"read it faster"、"slow it down". Otherwise omit `--speed` entirely so the request keeps
+its historical behaviour.
+
+- Range: any value from `0.5` to `2.0`, at most two decimals — it is a continuous range,
+  not a fixed set of steps.
+- Common values: `0.5`, `0.75`, `1` (default), `1.25`, `1.5`, `2`. Values in between such
+  as `0.85` or `1.35` are equally valid.
+- Meaning: the speaking rate of the generated audio, not a player playback rate. All
+  speakers in one episode share the same task-level speed.
+- Map vague wording conservatively: "慢一点" → `0.85`, "快一点" → `1.25`, "慢很多" → `0.5`,
+  "快很多" → `1.75`. When the user names a number, pass that number through unchanged.
+
+Show the speed in the confirmation summary only when it is not `1`.
+
 ### Step 6: Confirm & Generate
 
 Summarize all choices:
@@ -183,6 +202,7 @@ Ready to generate podcast:
   Mode: {mode}
   Language: {language}
   Speakers: {speaker name(s)}
+  Speed: {speed}x        # omit this line when speed is 1
   References: {yes/no + brief description}
 
   Proceed?
@@ -205,6 +225,7 @@ Wait for explicit confirmation before calling any CLI command. The user can adju
      --lang {en|zh|ja} \
      --speaker "{name}" \
      --speaker "{name2}" \
+     --speed {0.5-2.0} \
      --json
    ```
 
@@ -216,6 +237,7 @@ Wait for explicit confirmation before calling any CLI command. The user can adju
    - `--lang` — language code
    - `--speaker` — repeatable (max 2); use speaker display names
    - `--speaker-id` — alternative to `--speaker`; use speaker IDs instead of names
+   - `--speed` — generation speed multiplier `0.5`–`2.0` (max two decimals, default `1`); omit it unless the user asked for a different speed
    - Omit `--source-url` / `--source-text` if the user provided no references
 
    The CLI handles polling internally and returns the final result when generation completes.

--- a/tts/SKILL.md
+++ b/tts/SKILL.md
@@ -127,6 +127,23 @@ echo "$NEW_CONFIG" > "$CONFIG_PATH"
 CONFIG=$(cat "$CONFIG_PATH")
 ```
 
+### Generation Speed
+
+**Default: 1.0x (original speed). Never ask about speed.**
+
+Only pass `--speed` when the user explicitly asks for a faster or slower reading —
+"慢一点"、"快一点"、"1.25 倍速"、"read it faster". Otherwise omit the flag.
+
+- Range: any value from `0.5` to `2.0`, at most two decimals — a continuous range, not
+  fixed steps.
+- Common values: `0.5`, `0.75`, `1` (default), `1.25`, `1.5`, `2`; in-between values such
+  as `0.85` or `1.35` work too.
+- Meaning: the speaking rate of the generated audio, not a player playback rate.
+- Map vague wording conservatively: "慢一点" → `0.85`, "快一点" → `1.25`, "慢很多" → `0.5`,
+  "快很多" → `1.75`. A number the user names is passed through unchanged.
+
+Show the speed in the confirmation summary only when it is not `1`.
+
 ### Quick Mode — `$CMD_PREFIX create --mode direct`
 
 **Step 1: Extract text**
@@ -159,6 +176,7 @@ Ready to generate:
 
   Text: "{first 80 chars}..."
   Voice: {voice name}
+  Speed: {speed}x        # omit this line when speed is 1
 
 Proceed?
 ```
@@ -167,7 +185,7 @@ Proceed?
 
 For short text, pass inline:
 ```bash
-RESULT=$($CMD_PREFIX create --text "{text}" --mode direct --speaker "{name}" --lang {lang} --json 2>/tmp/lh-err)
+RESULT=$($CMD_PREFIX create --text "{text}" --mode direct --speaker "{name}" --lang {lang} [--speed {0.5-2.0}] --json 2>/tmp/lh-err)
 EXIT_CODE=$?
 
 if [ $EXIT_CODE -ne 0 ]; then
@@ -190,7 +208,7 @@ cat > /tmp/lh-content.txt << 'ENDCONTENT'
 Long text content goes here...
 ENDCONTENT
 
-RESULT=$($CMD_PREFIX create --text "$(cat /tmp/lh-content.txt)" --mode direct --speaker "{name}" --lang {lang} --json)
+RESULT=$($CMD_PREFIX create --text "$(cat /tmp/lh-content.txt)" --mode direct --speaker "{name}" --lang {lang} [--speed {0.5-2.0}] --json)
 AUDIO_URL=$(echo "$RESULT" | jq -r '.audioUrl')
 
 rm -f /tmp/lh-content.txt
@@ -269,6 +287,7 @@ Ready to generate:
     {name}: {voice}
     {name}: {voice}
   Segments: {count}
+  Speed: {speed}x        # omit this line when speed is 1
   Title: (auto-generated)
 
 Proceed?
@@ -280,7 +299,7 @@ Format the script text with speaker markers and submit. For multi-speaker script
 
 **Submit (foreground)** with `--no-wait`:
 ```bash
-RESULT=$($CMD_PREFIX create --text "{formatted script with speaker markers}" --mode smart --speaker "{name1}" --speaker "{name2}" --lang {lang} --no-wait --json)
+RESULT=$($CMD_PREFIX create --text "{formatted script with speaker markers}" --mode smart --speaker "{name1}" --speaker "{name2}" --lang {lang} [--speed {0.5-2.0}] --no-wait --json)
 ID=$(echo "$RESULT" | jq -r '.id')
 echo "Submitted: $ID"
 ```
@@ -293,7 +312,7 @@ SpeakerB: Second line of dialogue
 ...
 ENDCONTENT
 
-RESULT=$($CMD_PREFIX create --text "$(cat /tmp/lh-content.txt)" --mode smart --speaker "{name1}" --speaker "{name2}" --lang {lang} --no-wait --json)
+RESULT=$($CMD_PREFIX create --text "$(cat /tmp/lh-content.txt)" --mode smart --speaker "{name1}" --speaker "{name2}" --lang {lang} [--speed {0.5-2.0}] --no-wait --json)
 ID=$(echo "$RESULT" | jq -r '.id')
 
 rm -f /tmp/lh-content.txt


### PR DESCRIPTION
Closes part of marswaveai/listenhub-ralph#646

## 做了什么

`podcast` 与 `tts` 两个 skill 现在能理解用户说的生成语速并透传给 CLI 的 `--speed`。

- 各加一节「Generation Speed」：连续区间 0.5–2.0（最多两位小数，不是几个固定档），常用值 `0.5 / 0.75 / 1 / 1.25 / 1.5 / 2`，默认 `1`，并写明它是生成语速而不是播放器倍速、同一期播客所有角色共用同一个任务级语速。
- **默认 1.0×，永不追问**：用户没明说就不带 `--speed`，请求形状与改动前一致。
- 给出模糊说法的保守映射（"慢一点"→0.85、"快一点"→1.25、"慢很多"→0.5、"快很多"→1.75）；用户报了具体数字就原样透传。
- 生成命令块与 flag notes 加上 `--speed`；确认摘要里只在语速不是 1 时才显示该行。
- `CHANGELOG.md` 加 Unreleased 条目。

## 验证证据

本仓是纯 Markdown skill 文档，没有 lint / test / build 脚本（`package.json` 不存在，CI 只有 `claude.yml`）。做了人工检查：

- 两个 `SKILL.md` 的 YAML frontmatter 仍可解析（起止 `---` 位置正确，name/description/metadata 未动）。
- 触发词与 `When to Use` / `When NOT to Use` 未改，不影响 skill 的触发行为。
- 默认值检查：新增文案明确写了「Never ask this question / Never ask about speed」和「Otherwise omit the flag」，与 Contract 的「用户未指定时保持 1.0×，不额外追问」一致。
- 示例检查：命令块里的 `--speed` 写法与 listenhub-cli PR 实测通过的 `--speed <multiplier>` 一致（`0.5-2.0`，最多两位小数）。

## 依赖顺序

`--speed` 需要 listenhub-cli 发布带该 flag 的版本后才真正可用。skill 文档先行不会破坏现状（不带 flag 时行为不变），但**建议在 CLI 发版后再合并本 PR**，避免文档描述的能力早于 CLI 落地。

## 风险判定

**快车道（0 个独立 reviewer）**：`route-gates.py` 参考信号 `risk=normal`、`reasons=[]`、`nonDowngradable=false`，与人工判断一致。改动全是文档，不含任何可执行代码。

---
_Generated by [Claude Code](https://claude.ai/code/session_01MW3wFcDhSzjA4a46vMXwW6)_